### PR TITLE
Remove portion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "universal-pathlib~=0.2.6",
   "matplotlib~=3.10.1",
   "biopython~=1.85",
-  "portion~=2.6.1",
   "numba~=0.61.0",
   "tqdm~=4.67.1",
   "six~=1.17.0",
@@ -78,7 +77,6 @@ replace-imports-with-any = [
   "lightning.*",
   "numba.*",
   "pandas.*",
-  "portion.*",
   "torchmetrics.*",
   "Bio.*",
 ]

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -19,7 +19,9 @@ class Intervals:
 
     cds: set[tuple[int, int]]  # all CDS features
     utr: set[tuple[int, int]]  # all UTR features
-    intron: set[tuple[int, int]]  # all introns, inferred from space between CDS and UTR intervals
+    intron: set[
+        tuple[int, int]
+    ]  # all introns, inferred from space between CDS and UTR intervals
     intron_cds: set[tuple[int, int]]  # all introns that are fully contained within CDS
     exon: set[tuple[int, int]]  # all exons (union of CDS and UTR)
 
@@ -126,7 +128,7 @@ def blank_stats():
         ConfusionCounts(),
         ConfusionCounts(),
         ConfusionCounts(),
-        ConfusionCounts()
+        ConfusionCounts(),
     )
 
 
@@ -574,7 +576,7 @@ def overlap_stats(
             ),
             intron_longest=ConfusionCounts(
                 fn=len(true_intervals[tidx][true_longest_index[tidx]].intron)
-            )
+            ),
         )
     elif len(tindices) == 0:  # only one predicted feature, no true features
         return Stats(
@@ -606,7 +608,7 @@ def overlap_stats(
             ),
             intron_longest=ConfusionCounts(
                 fp=len(pred_intervals[pidx][pred_longest_index[pidx]].intron)
-            )
+            ),
         )
 
     # transcript level metrics
@@ -632,16 +634,10 @@ def overlap_stats(
     for pname, pinterval in pred_intervals.items():
         for ptidx, ptranscript in enumerate(pinterval):
             if ptidx == pred_longest_index[pname]:
-                pred_exon_cds_intervals_longest.extend(
-                    ptranscript.cds
-                )
+                pred_exon_cds_intervals_longest.extend(ptranscript.cds)
                 pred_exon_intervals_longest.extend(ptranscript.exon)
-                pred_intron_cds_intervals_longest.extend(
-                    ptranscript.intron_cds
-                )
-                pred_intron_intervals_longest.extend(
-                    ptranscript.intron
-                )
+                pred_intron_cds_intervals_longest.extend(ptranscript.intron_cds)
+                pred_intron_intervals_longest.extend(ptranscript.intron)
 
             pred_exon_cds_intervals.update(ptranscript.cds)
             pred_exon_intervals.update(ptranscript.exon)
@@ -670,16 +666,10 @@ def overlap_stats(
     for tname, tinterval in true_intervals.items():
         for ttidx, ttranscript in enumerate(tinterval):
             if ttidx == true_longest_index[tname]:
-                true_exon_cds_intervals_longest.extend(
-                    ttranscript.cds
-                )
+                true_exon_cds_intervals_longest.extend(ttranscript.cds)
                 true_exon_intervals_longest.extend(ttranscript.exon)
-                true_intron_cds_intervals_longest.extend(
-                    ttranscript.intron_cds
-                )
-                true_intron_intervals_longest.extend(
-                    ttranscript.intron
-                )
+                true_intron_cds_intervals_longest.extend(ttranscript.intron_cds)
+                true_intron_intervals_longest.extend(ttranscript.intron)
 
             true_exon_cds_intervals.update(ttranscript.cds)
             true_exon_intervals.update(ttranscript.exon)
@@ -726,7 +716,7 @@ def overlap_stats(
         exon_cds_counts_longest,
         exon_counts_longest,
         intron_cds_counts_longest,
-        intron_counts_longest
+        intron_counts_longest,
     )
 
 
@@ -763,9 +753,9 @@ def transcript_to_intervals(transcript: SeqFeature):
     while idx < len(temp_interval):
         start = temp_interval[idx][0]
         end = temp_interval[idx][1]
-        while idx+1 < len(temp_interval):
-            if temp_interval[idx+1][0] <= end:
-                end = temp_interval[idx+1][1]
+        while idx + 1 < len(temp_interval):
+            if temp_interval[idx + 1][0] <= end:
+                end = temp_interval[idx + 1][1]
                 idx += 1
             else:
                 break
@@ -777,12 +767,11 @@ def transcript_to_intervals(transcript: SeqFeature):
     intron_interval = []
 
     for idx in range(len(exon_interval) - 1):
-        intron_interval.append((exon_interval[idx][1], exon_interval[idx+1][0]))
+        intron_interval.append((exon_interval[idx][1], exon_interval[idx + 1][0]))
 
     intron_cds_interval = []
     for idx in range(len(cds_interval) - 1):
-        intron_cds_interval.append((cds_interval[idx][1], cds_interval[idx+1][0]))
-
+        intron_cds_interval.append((cds_interval[idx][1], cds_interval[idx + 1][0]))
 
     return Intervals(
         cds=set(cds_interval),

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -2,7 +2,6 @@
 
 import itertools
 import numpy as np
-#import portion as P
 from Bio import SeqFeature
 from numba import njit
 from dataclasses import dataclass
@@ -76,7 +75,7 @@ class ConfusionCounts:
 
         return str(precision) + "\t" + str(recall) + "\t" + str(f1) + "\n"
 
-# TODO
+
 @dataclass
 class Stats:
     """
@@ -111,7 +110,7 @@ class Stats:
             self.intron_longest + other.intron_longest,
         )
 
-# TODO
+
 def blank_stats():
     """
     Initialize a blank Stats object
@@ -127,7 +126,7 @@ def blank_stats():
         ConfusionCounts(),
         ConfusionCounts(),
         ConfusionCounts(),
-        ConfusionCounts(),
+        ConfusionCounts()
     )
 
 
@@ -419,7 +418,7 @@ def do_genes_match(
         # cds's not equal, genes not equal on any level
         return {"cds": False, "intron": False, "full": False}
 
-# TODO
+
 def evaluate_transcript_matches(
     pred_intervals: dict,
     true_intervals: dict,
@@ -497,7 +496,7 @@ def evaluate_transcript_matches(
 
     return tcds, tintron, tfull
 
-# TODO
+
 def overlap_stats(
     pred_features: list[SeqFeature],
     true_features: list[SeqFeature],

--- a/src/gff_eval.py
+++ b/src/gff_eval.py
@@ -62,15 +62,6 @@ def write_stats(
         out_handle.write("intron\t")
         out_handle.write(master_stats.intron.to_score_string(as_percentage))
 
-        out_handle.write("base_cds\t")
-        out_handle.write(master_stats.base_cds.to_score_string(as_percentage))
-
-        out_handle.write("base_utr\t")
-        out_handle.write(master_stats.base_utr.to_score_string(as_percentage))
-
-        out_handle.write("base_exon\t")
-        out_handle.write(master_stats.base_exon.to_score_string(as_percentage))
-
 
 def calc_stats_for_contig_and_strand(
     pred_contig: SeqRecord,

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,6 @@ dependencies = [
     { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "portion" },
     { name = "pydantic" },
     { name = "scikit-learn" },
     { name = "six" },
@@ -388,7 +387,6 @@ requires-dist = [
     { name = "numba", specifier = "~=0.61.0" },
     { name = "numpy", specifier = "~=2.1.2" },
     { name = "pandas", specifier = "~=2.2.3" },
-    { name = "portion", specifier = "~=2.6.1" },
     { name = "pydantic", specifier = "~=2.10.6" },
     { name = "scikit-learn", specifier = "~=1.6.1" },
     { name = "six", specifier = "~=1.17.0" },
@@ -938,18 +936,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "portion"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/eb/fb2cc91b0214c0c6028cb4b29d309142687c740d1daf7c36c771a0aa5ac1/portion-2.6.1.tar.gz", hash = "sha256:44b1f7d57e052993c4157e519dc447e57b87a4e5e00a77c1c50e7044104e53c6", size = 61345, upload-time = "2025-05-25T13:50:46.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/9e/21c4088d1d433cfbf0578f138a6df59527dbd9e9d67355ee31b17e6dc774/portion-2.6.1-py3-none-any.whl", hash = "sha256:764d0be5479842f011feccc6f4bf80454dd944ef16309fceb2b5ae229cf05df3", size = 27389, upload-time = "2025-05-25T13:50:45.295Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -113,31 +113,7 @@ wheels = [
 name = "causal-conv1d"
 version = "1.5.0.post8"
 source = { git = "https://github.com/Dao-AILab/causal-conv1d?tag=v1.5.0.post8#82867a9d2e6907cc0f637ac6aff318f696838548" }
-resolution-markers = [
-    "platform_machine != 'x86_64' or sys_platform != 'linux'",
-]
 dependencies = [
-    { name = "einops", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-]
-
-[[package]]
-name = "causal-conv1d"
-version = "1.5.0.post8"
-source = { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/causal_conv1d-1.5.0.post8-cp312-cp312-linux_x86_64.whl" }
-resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/causal_conv1d-1.5.0.post8-cp312-cp312-linux_x86_64.whl", hash = "sha256:13e05f9c51cf4fd81c0231fab306327b3353679b56bd08afe494f76ef782ec75" },
-]
-
-[package.metadata]
-requires-dist = [
     { name = "einops" },
     { name = "torch" },
 ]
@@ -357,10 +333,8 @@ dependencies = [
 
 [package.optional-dependencies]
 mamba = [
-    { name = "causal-conv1d", version = "1.5.0.post8", source = { git = "https://github.com/Dao-AILab/causal-conv1d?tag=v1.5.0.post8#82867a9d2e6907cc0f637ac6aff318f696838548" }, marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "causal-conv1d", version = "1.5.0.post8", source = { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/causal_conv1d-1.5.0.post8-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mamba-ssm", version = "2.2.4", source = { git = "https://github.com/state-spaces/mamba?tag=v2.2.4#95d8aba8a8c75aedcaa6143713b11e745e7cd0d9" }, marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "mamba-ssm", version = "2.2.4", source = { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/mamba_ssm-2.2.4-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "causal-conv1d" },
+    { name = "mamba-ssm" },
 ]
 torch = [
     { name = "lightning" },
@@ -371,6 +345,7 @@ torch = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -378,11 +353,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "biopython", specifier = "~=1.85" },
-    { name = "causal-conv1d", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'mamba'", url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/causal_conv1d-1.5.0.post8-cp312-cp312-linux_x86_64.whl" },
-    { name = "causal-conv1d", marker = "(python_full_version != '3.12.*' and extra == 'mamba') or (platform_machine != 'x86_64' and extra == 'mamba') or (sys_platform != 'linux' and extra == 'mamba')", git = "https://github.com/Dao-AILab/causal-conv1d?tag=v1.5.0.post8" },
+    { name = "causal-conv1d", marker = "extra == 'mamba'", git = "https://github.com/Dao-AILab/causal-conv1d?tag=v1.5.0.post8" },
     { name = "lightning", marker = "extra == 'torch'", specifier = "~=2.5.1" },
-    { name = "mamba-ssm", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'mamba'", url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/mamba_ssm-2.2.4-cp312-cp312-linux_x86_64.whl" },
-    { name = "mamba-ssm", marker = "(python_full_version != '3.12.*' and extra == 'mamba') or (platform_machine != 'x86_64' and extra == 'mamba') or (sys_platform != 'linux' and extra == 'mamba')", git = "https://github.com/state-spaces/mamba?tag=v2.2.4" },
+    { name = "mamba-ssm", marker = "extra == 'mamba'", git = "https://github.com/state-spaces/mamba?tag=v2.2.4" },
     { name = "matplotlib", specifier = "~=3.10.1" },
     { name = "numba", specifier = "~=0.61.0" },
     { name = "numpy", specifier = "~=2.1.2" },
@@ -403,6 +376,7 @@ provides-extras = ["torch", "mamba"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pyrefly", specifier = ">=0.32.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
@@ -561,31 +535,7 @@ wheels = [
 name = "mamba-ssm"
 version = "2.2.4"
 source = { git = "https://github.com/state-spaces/mamba?tag=v2.2.4#95d8aba8a8c75aedcaa6143713b11e745e7cd0d9" }
-resolution-markers = [
-    "platform_machine != 'x86_64' or sys_platform != 'linux'",
-]
 dependencies = [
-    { name = "einops", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
-]
-
-[[package]]
-name = "mamba-ssm"
-version = "2.2.4"
-source = { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/mamba_ssm-2.2.4-cp312-cp312-linux_x86_64.whl" }
-resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://github.com/Open-Athena/python-wheels/releases/download/v0.0.1/mamba_ssm-2.2.4-cp312-cp312-linux_x86_64.whl", hash = "sha256:2c4b420217da39feeed12e0c87dcc85195a306e42b3e21b9f9736414bf50c3bb" },
-]
-
-[package.metadata]
-requires-dist = [
     { name = "einops" },
     { name = "torch" },
 ]
@@ -782,7 +732,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.7.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/dc/dc825c4b1c83b538e207e34f48f86063c88deaa35d46c651c7c181364ba2/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:6d011159a158f3cfc47bf851aea79e31bcff60d530b70ef70474c84cac484d07", size = 726851421, upload-time = "2025-02-06T22:18:29.812Z" },
@@ -793,7 +743,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/26/b53c493c38dccb1f1a42e1a21dc12cba2a77fbe36c652f7726d9ec4aba28/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da650080ab79fcdf7a4b06aa1b460e99860646b176a43f6208099bdc17836b6a", size = 193118795, upload-time = "2025-01-23T17:56:30.536Z" },
@@ -820,9 +770,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.2.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/08/953675873a136d96bb12f93b49ba045d1107bc94d2551c52b12fa6c7dec3/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4d1354102f1e922cee9db51920dba9e2559877cf6ff5ad03a00d853adafb191b", size = 260373342, upload-time = "2025-01-23T17:58:56.406Z" },
@@ -833,7 +783,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.7.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/ab/31e8149c66213b846c082a3b41b1365b831f41191f9f40c6ddbc8a7d550e/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c1b61eb8c85257ea07e9354606b26397612627fdcd327bfd91ccf6155e7c86d", size = 292064180, upload-time = "2025-01-23T18:00:23.233Z" },
@@ -1034,6 +984,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/c9/b4594e6a81371dfa9eb7a2c110ad682acf985d96115ae8b25a1d63b4bf3b/pyparsing-3.2.4.tar.gz", hash = "sha256:fff89494f45559d0f2ce46613b419f632bbb6afbdaed49696d322bcf98a58e99", size = 1098809, upload-time = "2025-09-13T05:47:19.732Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/b8/fbab973592e23ae313042d450fc26fa24282ebffba21ba373786e1ce63b4/pyparsing-3.2.4-py3-none-any.whl", hash = "sha256:91d0fcde680d42cd031daf3a6ba20da3107e08a75de50da58360e7d94ab24d36", size = 113869, upload-time = "2025-09-13T05:47:17.863Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/5d/3c448fb19a81a21a1f7e9a76280473273e85a2a5df7c0a2195deccf3c2a2/pyrefly-0.33.0.tar.gz", hash = "sha256:30c842ba7a6142c2e5cb8638b829d2b093c966e4b1211fee81ed42fedaa08632", size = 1399636, upload-time = "2025-09-15T14:57:04.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/e6/2ca0921cde526c40a55392001e15eba9078d3b0cfcb0e2dfbcc92caa3477/pyrefly-0.33.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f235737e53a70925b94b8928131d81d6097cbf5413011c10d8730bae3970ad42", size = 6676391, upload-time = "2025-09-15T14:56:48.652Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/45/5401c34f85e408b98cc0583a25e591e5da0f04876da708286e69d4091c79/pyrefly-0.33.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:21bc7d9d2fd63d6144b156ae56ecc84ec30e29b8024fcc6ddf7c3ea2faab4025", size = 6218255, upload-time = "2025-09-15T14:56:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/d05f80582979e20630741d5995fbcfc74951e755a6052c31c4e3c361d143/pyrefly-0.33.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c63518cbbe50d4f63f1d8876466744787110ab218773f244f3bd7c6c923717a9", size = 6461939, upload-time = "2025-09-15T14:56:52.893Z" },
+    { url = "https://files.pythonhosted.org/packages/82/eb/7a94d9fe7ce7099fdacb9056b647cf7fddc94cc32e511194ac5b043619ba/pyrefly-0.33.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66eefc5453b097206b133d0ba205d07c815147239dbd40dbeeec1c066dd8c02c", size = 7277173, upload-time = "2025-09-15T14:56:54.957Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/90/91014e9e1525af0e53c9663782453311e19fd886098b1dceee5d7d977a04/pyrefly-0.33.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33ed004ed22d207f68a558b2a38ce671200c0fcdf3f810b729fa481e350a8246", size = 6943644, upload-time = "2025-09-15T14:56:56.646Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/f99f8b3cf7289617b80f4903d3c5b60dbb2bb948b394baaf20d6efeaa9e3/pyrefly-0.33.0-py3-none-win32.whl", hash = "sha256:bf814c4468cb9b9b35ca2d7d44947995a6543c3bbd03fe3cb2e3fdfde22a751b", size = 6438608, upload-time = "2025-09-15T14:56:58.842Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/fa/61a929f85e6423f0455a22bb4dd609888d3940dd25f719bcf52822d147f2/pyrefly-0.33.0-py3-none-win_amd64.whl", hash = "sha256:5b08be1a43e51e2aa7e5125ba8b5c30d07f76ea965b857b10322667e96f396e6", size = 6864842, upload-time = "2025-09-15T14:57:00.72Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e4/88b64c6d4a7a4f57f4530226734efab23ada37087e4c41848491410660fd/pyrefly-0.33.0-py3-none-win_arm64.whl", hash = "sha256:b858343993ee10fb8173348ef2ac879ff19d2ef4bbc4190b5c447fa5dd80a94d", size = 6476161, upload-time = "2025-09-15T14:57:03.316Z" },
 ]
 
 [[package]]
@@ -1250,15 +1216,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Removed the package `portion` from the dependency list and replaced with built-in sets. This necessitated removing base-level metrics (e.g., `base_cds`, `base_exon`, and `base_utr`, but all other metrics are present. Unit tests have been updated to reflect the data structure changes.