### PR TITLE
Align docstrings with numpydoc style guidelines

### DIFF
--- a/src/hub.py
+++ b/src/hub.py
@@ -8,6 +8,27 @@ def load_base_model(
     dtype=torch.bfloat16,
     randomize: bool = False,
 ) -> AutoModel:
+    """Load a Hugging Face base encoder with optional random initialization.
+
+    Parameters
+    ----------
+    path : str
+        Repository identifier or local path of the model to load.
+    revision : str or None, optional
+        Specific revision of the model to load, by default ``None`` which
+        selects the latest revision.
+    dtype : torch.dtype, optional
+        Torch data type to use for the returned model, by default
+        ``torch.bfloat16``.
+    randomize : bool, optional
+        If ``True``, instantiate the model from configuration without
+        pretrained weights. By default ``False``.
+
+    Returns
+    -------
+    transformers.AutoModel
+        The instantiated model ready for inference or fine-tuning.
+    """
     config = AutoConfig.from_pretrained(path, revision=revision, trust_remote_code=True)
     if randomize:
         base_model = AutoModel.from_config(config, dtype=dtype, trust_remote_code=True)


### PR DESCRIPTION
## Summary
- update inference and export scripts with numpydoc-compliant docstrings describing parameters and returns
- document visualization utilities and base model loader to satisfy the NumPy docstring guide

## Testing
- python -m compileall scripts/predict.py src/hub.py src/visualization.py

------
https://chatgpt.com/codex/tasks/task_e_68d687fcf1a8832e9849013a8591ab82