### PR TITLE
Use uv-managed pyrefly in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,10 @@ repos:
     hooks:
       - id: validate-pyproject
         additional_dependencies: ["validate-pyproject-schema-store[all]"]
-  - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.0.1
+  - repo: local
     hooks:
       - id: pyrefly-typecheck-system
+        name: pyrefly-typecheck-system
+        entry: uv run pyrefly check
+        language: system
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -429,10 +429,10 @@ uv sync --dev
 pre-commit install
 
 # Check types
-pyrefly check --summarize-errors
+uv run pyrefly check --summarize-errors
 
 # Run tests that don't require GPUs
-pytest -vrs
+uv run pytest -vrs
 ```
 
 ### Hugging Face


### PR DESCRIPTION
## Summary
- replace the pyrefly pre-commit hook with a local  entry so hook runs and documented local runs use the same executable
- update the README development commands to use  for both pyrefly and pytest

## Validation
- uv run pyrefly check
- uv run pre-commit run --all-files
- uv run pytest