### PR TITLE
Cast modernbert to bf16 and use FA2

### DIFF
--- a/src/modeling.py
+++ b/src/modeling.py
@@ -368,6 +368,8 @@ class GeneClassifier(L.LightningModule):
                 max_position_embeddings=config.max_sequence_length,
                 attention_dropout=self.config.dropout,
                 mlp_dropout=self.config.dropout,
+                dtype=torch.bfloat16,
+                attn_implementation="flash_attention_2",
             )
             self.head_encoder = ModernBertModel(self.head_config)
 


### PR DESCRIPTION
By default, ModernBert is in fp32 and does not use Flash Attention 2(see https://huggingface.co/docs/transformers/model_doc/modernbert#transformers.ModernBertConfig , relevant excerpt below)
> Padding-free inference and training requires flash_attention_2 as the attention implementation. Since ModernBERT no longer defaults to FlashAttention2, you must explicitly set attn_implementation="flash_attention_2" when loading the model for padding-free usage.

This PR adjusts the config to make bf16 the default and to force FA2 usage (FA2 is already in the requirements). On an a6000, this reduces the train time for a single epoch using the  default config in `train.sh` with a bs=2 by 3x (~100hours -> ~37 hours on an a6000). 