### PR TITLE
Add ORF validation via frame-aware decoding and CDS repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,18 @@ If set, overrides automatic DDP/SLURM detection. Can also be set via LAUNCHER en
 (Default: python)
 * `--model-checkpoint` - Overrides the GeneCAD head model set by `--mode`. Accepts a local path to a `.ckpt` file or a
 HuggingFace model repo ID. Note that this does **not** override the base PlantCAD model set by `--mode`
+* `--no-frame-aware` - Decode with the original 5-state Viterbi, which ignores the genome sequence. By default,
+decoding is frame-aware: the CDS is constrained to begin on ATG, end on a stop codon, stay in frame across introns,
+and contain no in-frame stop, so every predicted CDS translates cleanly.
+* `--min-intron-length` - Shortest intron frame-aware decoding may emit. Guards against short introns being invented
+to step over an in-frame stop codon. Lower it for compact genomes with genuinely short introns. (Default: 20)
+* `--allow-u12-introns` - Also allow U12-type AT-AC introns during frame-aware decoding, in addition to the default
+GT-AG/GC-AG. These are real but rare; enabling this roughly doubles the intron state count and slows decoding
+accordingly.
+* `--orf-max-shift` - Maximum distance (nt, in spliced transcript coordinates) that the start and stop codon may be
+moved when repairing CDS boundaries against the genome sequence. Repairs never alter exon structure and never leave
+the predicted exonic sequence; models that cannot be resolved this way are flagged `partial=true` rather than
+forced. Use 0 to disable repair. (Default: 300)
 
 #### Pipeline Breakdown
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GeneCAD: Plant Genome Annotation with a DNA Foundation Model
 
-![](https://img.shields.io/badge/version-0.3.0-blue)
+![](https://img.shields.io/badge/version-0.4.0-blue)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/plantcad/genecad/actions/workflows/ci.yaml/badge.svg)](https://github.com/plantcad/genecad/actions/workflows/ci.yaml)
 [![bioRxiv](https://img.shields.io/badge/bioRxiv-10.1101/2025.10.31.685877-b31b1b.svg)](https://doi.org/10.1101/2025.10.31.685877)

--- a/docs/detect_intervals.md
+++ b/docs/detect_intervals.md
@@ -28,8 +28,16 @@ UTR must follow CDS, etc.). The direct method creates intervals directly from th
 predicting genic regions (CDS, 3' UTR, 5' UTR, or intron). Note that this value is applied before
 softmax, and so can be greater than 1.
 * `--keep-incomplete-features` - Flag. If set, gene models missing UTRs are allowed.
+* `--input-fasta`, `-f` - Genome FASTA used for prediction. When given, decoding becomes frame-aware: the CDS is
+constrained to begin on ATG, end on a stop codon, stay in frame across introns, and contain no in-frame stop.
+Ignored when `--decode-direct` is set.
+* `--min-intron-length` - Shortest intron frame-aware decoding may emit. Guards against short introns being invented
+to step over an in-frame stop codon. Default: 20.
 * `--domain` - Domain sets the transition probabilities between states based on empirical observation from
 different types of organisms. Default: plant. Options: plant, animal.
+* `--allow-u12-introns` - Flag. Also allow U12-type AT-AC introns during frame-aware decoding, in addition to the
+default GT-AG/GC-AG. These are real but rare; enabling this roughly doubles the intron state count and slows
+decoding accordingly. Ignored unless `--input-fasta` is set.
 
 ### Next Step
 

--- a/predict.sh
+++ b/predict.sh
@@ -24,7 +24,24 @@ Options:
                                                 Minimum transcript length (bp) used during GFF export.
                                                 Higher values can reduce tiny fragments and speed up export.
                                                 (default: 3)
-    -c, --cpu-workers N   CPU worker processes used in GFF export transcript grouping.
+      --orf-max-shift N       Maximum distance (nt, in spliced transcript coordinates)
+                                                that the start and stop codon may be moved when
+                                                repairing CDS boundaries against the genome
+                                                sequence. Repairs never alter exon structure and
+                                                never leave the predicted exonic sequence; models
+                                                that cannot be resolved are flagged partial=true
+                                                rather than forced. Use 0 to disable repair.
+                                                (default: 300)
+    --no-frame-aware        Decode with the original 5-state Viterbi, which ignores the
+                                                genome sequence. By default decoding is frame-aware: the
+                                                CDS is constrained to begin on ATG, end on a stop codon,
+                                                stay in frame across introns, and contain no in-frame
+                                                stop, so every predicted CDS translates cleanly.
+    --min-intron-length N   Shortest intron frame-aware decoding may emit (default: 20).
+                                                Guards against short introns being invented to step over
+                                                an in-frame stop codon. Lower it for compact genomes
+                                                with genuinely short introns.
+  -c, --cpu-workers N   CPU worker processes used in GFF export transcript grouping.
                                                 Uses an order-preserving map so outputs remain deterministic.
                                                 (default: 1)
   -b, --batch-size N    Inference batch size per GPU (default: auto — scaled to GPU VRAM)
@@ -78,6 +95,9 @@ BATCH_SIZE_ARG="auto"
 GPUS_ARG="0"
 TOP_N_CONTIGS="all"
 MIN_TRANSCRIPT_LENGTH="3"
+ORF_MAX_SHIFT="300"
+FRAME_AWARE="1"
+MIN_INTRON_LENGTH="20"
 CPU_WORKERS="1"
 LAUNCHER_ARG="${LAUNCHER:-}"
 MODEL_CHECKPOINT_ARG=""
@@ -91,6 +111,9 @@ while [[ $# -gt 0 ]]; do
     -m|--mode)       MODE="$2";            shift 2 ;;
     -n|--top-n-contigs) TOP_N_CONTIGS="$2"; shift 2 ;;
     -l|--min-transcript-length) MIN_TRANSCRIPT_LENGTH="$2"; shift 2 ;;
+    --orf-max-shift) ORF_MAX_SHIFT="$2"; shift 2 ;;
+    --no-frame-aware) FRAME_AWARE="0"; shift ;;
+    --min-intron-length) MIN_INTRON_LENGTH="$2"; shift 2 ;;
     -c|--cpu-workers) CPU_WORKERS="$2"; shift 2 ;;
     -b|--batch-size) BATCH_SIZE_ARG="$2"; shift 2 ;;
     -g|--gpus)       GPUS_ARG="$2";       shift 2 ;;
@@ -111,6 +134,16 @@ fi
 
 if ! [[ "$MIN_TRANSCRIPT_LENGTH" =~ ^[0-9]+$ ]]; then
     echo "Error: --min-transcript-length must be a non-negative integer."
+    exit 1
+fi
+
+if ! [[ "$ORF_MAX_SHIFT" =~ ^[0-9]+$ ]]; then
+    echo "Error: --orf-max-shift must be a non-negative integer."
+    exit 1
+fi
+
+if ! [[ "$MIN_INTRON_LENGTH" =~ ^[0-9]+$ ]] || [[ "$MIN_INTRON_LENGTH" -lt 5 ]]; then
+    echo "Error: --min-intron-length must be an integer of at least 5."
     exit 1
 fi
 
@@ -190,6 +223,8 @@ echo "Species ID:  $SPECIES_ID"
 echo "Mode:        $MODE  ($BASE_MODEL + $HEAD_MODEL)"
 echo "Top contigs: $TOP_N_CONTIGS"
 echo "Min tx len:  $MIN_TRANSCRIPT_LENGTH"
+echo "ORF shift:   $ORF_MAX_SHIFT"
+echo "Frame-aware: $FRAME_AWARE (min intron $MIN_INTRON_LENGTH)"
 echo "CPU workers: $CPU_WORKERS"
 echo "================================================================="
 
@@ -391,9 +426,9 @@ process_chromosome() {
 
     # --- Step 1: Extract Sequences ---
     if [[ -e $SEQUENCES_ZARR ]]; then
-        echo "${LOG_PREFIX} [1/7] Skipping — sequences.zarr already exists"
+        echo "${LOG_PREFIX} [1/8] Skipping — sequences.zarr already exists"
     else
-        echo "${LOG_PREFIX} [1/7] Extracting sequences..."
+        echo "${LOG_PREFIX} [1/8] Extracting sequences..."
         $PYTHON "$SCRIPT_DIR/scripts/extract_fasta.py" \
             --species-id "$SPECIES_ID" \
             --input-fasta "$INPUT_FILE" \
@@ -404,7 +439,7 @@ process_chromosome() {
 
     # --- Step 2: Predict ---
     if [[ -e $PREDICTIONS_DIR ]]; then
-        echo "${LOG_PREFIX} [2/7] Skipping — predictions dir already exists"
+        echo "${LOG_PREFIX} [2/8] Skipping — predictions dir already exists"
     else
         local gpu_id="$GPU_ID"
         local bs="$BATCH_SIZE"
@@ -414,7 +449,7 @@ process_chromosome() {
         while [[ $attempt -lt $max_attempts ]]; do
             local exit_code=0
             if [[ "$PREDICT_MODE" == "ddp" ]]; then
-                echo "${LOG_PREFIX} [2/7] Prediction via DDP (batch=${bs}/GPU, attempt $((attempt+1))/${max_attempts})..."
+                echo "${LOG_PREFIX} [2/8] Prediction via DDP (batch=${bs}/GPU, attempt $((attempt+1))/${max_attempts})..."
                 CUDA_VISIBLE_DEVICES="$GPU_LIST_STR" \
                 $PY_LAUNCHER \
                     "$SCRIPT_DIR/scripts/predict.py" \
@@ -429,7 +464,7 @@ process_chromosome() {
                     --window-size 8192 \
                     --stride 4096 || exit_code=$?
             elif [[ "$PREDICT_MODE" == "ddp_slurm" ]]; then
-                echo "${LOG_PREFIX} [2/7] Prediction via SLURM distributed (batch=${bs}/GPU, attempt $((attempt+1))/${max_attempts})..."
+                echo "${LOG_PREFIX} [2/8] Prediction via SLURM distributed (batch=${bs}/GPU, attempt $((attempt+1))/${max_attempts})..."
                 $PY_LAUNCHER "$SCRIPT_DIR/scripts/predict.py" \
                     --chromosome-id "$CHR_ID" \
                     --input-zarr $SEQUENCES_ZARR \
@@ -442,7 +477,7 @@ process_chromosome() {
                     --window-size 8192 \
                     --stride 4096 || exit_code=$?
             else
-                echo "${LOG_PREFIX} [2/7] Prediction on GPU ${gpu_id} (batch=${bs}, attempt $((attempt+1))/${max_attempts})..."
+                echo "${LOG_PREFIX} [2/8] Prediction on GPU ${gpu_id} (batch=${bs}, attempt $((attempt+1))/${max_attempts})..."
                 CUDA_VISIBLE_DEVICES="$gpu_id" \
                 $PY_LAUNCHER "$SCRIPT_DIR/scripts/predict.py" \
                     --chromosome-id "$CHR_ID" \
@@ -460,7 +495,7 @@ process_chromosome() {
             if [[ $exit_code -eq 0 ]]; then
                 success=1
                 if [[ $attempt -gt 0 ]]; then
-                    echo "${LOG_PREFIX} [2/7] Succeeded with batch size ${bs} after ${attempt} retry(s)."
+                    echo "${LOG_PREFIX} [2/8] Succeeded with batch size ${bs} after ${attempt} retry(s)."
                     echo "${LOG_PREFIX}   TIP: Add '-b ${bs}' to future runs to skip probing."
                 fi
                 break
@@ -468,7 +503,7 @@ process_chromosome() {
             local next_bs=$(( bs * 4 / 5 ))   # reduce by 20%
             [[ $next_bs -ge $bs ]] && next_bs=$(( bs - 1 ))  # guard against bs<5 rounding to same value
             [[ $next_bs -lt 1 ]] && next_bs=1
-            echo "${LOG_PREFIX} [2/7] Failed (exit ${exit_code}). Reducing batch size by 20%%: ${bs} → ${next_bs}..."
+            echo "${LOG_PREFIX} [2/8] Failed (exit ${exit_code}). Reducing batch size by 20%%: ${bs} → ${next_bs}..."
             bs=$next_bs
             rm -rf $PREDICTIONS_DIR
             attempt=$(( attempt + 1 ))
@@ -482,20 +517,21 @@ process_chromosome() {
 
     # --- Step 3: Detect Intervals ---
     if [[ -e $INTERVALS_ZARR ]]; then
-        echo "${LOG_PREFIX} [3/7] Skipping — intervals.zarr already exists"
+        echo "${LOG_PREFIX} [3/8] Skipping — intervals.zarr already exists"
     else
-        echo "${LOG_PREFIX} [3/7] Detecting intervals (Viterbi decoding)..."
+        echo "${LOG_PREFIX} [3/8] Detecting intervals (Viterbi decoding)..."
         $PYTHON "$SCRIPT_DIR/scripts/detect_intervals.py" \
             --input-dir $PREDICTIONS_DIR \
             --output-zarr $INTERVALS_ZARR \
-            --domain "$MODE"
+            --domain "$MODE" \
+            "${FRAME_AWARE_ARGS[@]}"
     fi
 
     # --- Step 4: Export Raw GFF ---
     if [[ -f $RAW_GENECAD_GFF ]]; then
-        echo "${LOG_PREFIX} [4/7] Skipping — predictions_raw.gff already exists"
+        echo "${LOG_PREFIX} [4/8] Skipping — predictions_raw.gff already exists"
     else
-        echo "${LOG_PREFIX} [4/7] Exporting raw GFF..."
+        echo "${LOG_PREFIX} [4/8] Exporting raw GFF..."
         local export_tqdm_args=()
         if [[ -n "$gpu_id" ]]; then
             export_tqdm_args=(--tqdm-position "$gpu_id")
@@ -509,7 +545,7 @@ process_chromosome() {
     fi
 
     # --- Step 5: Post-processing Filters ---
-    echo "${LOG_PREFIX} [5/7] Filtering features..."
+    echo "${LOG_PREFIX} [5/8] Filtering features..."
 
     if [[ -f $FILTERED_GENECAD_GFF ]]; then
         echo "${LOG_PREFIX}   Skipping feature-length filter — output already exists"
@@ -521,6 +557,12 @@ process_chromosome() {
 
     echo "${LOG_PREFIX} Done!"
 }
+
+if [[ "$FRAME_AWARE" == "1" ]]; then
+    FRAME_AWARE_ARGS=(--input-fasta "$INPUT_FILE" --min-intron-length "$MIN_INTRON_LENGTH")
+else
+    FRAME_AWARE_ARGS=()
+fi
 
 export -f process_chromosome
 export OUTPUT_DIR SPECIES_ID BASE_MODEL HEAD_MODEL TOKENIZER_PATH DTYPE PYTHON PYTHONPATH
@@ -632,10 +674,11 @@ done
 # =================================================================
 echo ""
 echo "================================================================="
-echo "[6/7] Merging per-chromosome GFFs into single files..."
+echo "[6/8] Merging per-chromosome GFFs into single files..."
 echo "================================================================="
 
 RAW_GFF="$OUTPUT_DIR/${SPECIES_ID}_GeneCAD_raw.gff"
+ORF_GFF="$OUTPUT_DIR/${SPECIES_ID}_GeneCAD_orf.gff"
 FINAL_GFF="$OUTPUT_DIR/${SPECIES_ID}_GeneCAD_final.gff"
 
 if [[ -f "$RAW_GFF" ]]; then
@@ -648,14 +691,33 @@ fi
 
 echo ""
 echo "================================================================="
-echo "[7/7] Running protein refinement on merged predictions..."
+echo "[7/8] Repairing CDS boundaries against the genome sequence..."
+echo "================================================================="
+
+if [[ "$ORF_MAX_SHIFT" -eq 0 ]]; then
+    echo "Skipping ORF repair — disabled via --orf-max-shift 0"
+    ORF_GFF="$RAW_GFF"
+elif [[ -f "$ORF_GFF" ]]; then
+    echo "Skipping ORF repair — ${SPECIES_ID}_GeneCAD_orf.gff already exists"
+else
+    $PYTHON "$SCRIPT_DIR/scripts/fix_orf.py" \
+        --input-gff "$RAW_GFF" \
+        --input-fasta "$INPUT_FILE" \
+        --output-gff "$ORF_GFF" \
+        --max-shift "$ORF_MAX_SHIFT" \
+        --report "$OUTPUT_DIR/${SPECIES_ID}_GeneCAD_orf_report.tsv"
+fi
+
+echo ""
+echo "================================================================="
+echo "[8/8] Running protein refinement on merged predictions..."
 echo "================================================================="
 
 if [[ -f "$FINAL_GFF" ]]; then
     echo "Skipping refinement — ${SPECIES_ID}_GeneCAD_final.gff already exists"
 else
     $PYTHON "$SCRIPT_DIR/scripts/refine.py" \
-        --input-gff "$RAW_GFF" \
+        --input-gff "$ORF_GFF" \
         --input-fasta "$INPUT_FILE" \
         --output-gff "$FINAL_GFF" \
         --gpus "$GPU_LIST_STR"
@@ -665,5 +727,6 @@ echo ""
 echo "================================================================="
 echo "All done! Final predictions saved to:"
 echo "Raw:   $RAW_GFF"
+echo "ORF:   $ORF_GFF"
 echo "Final: $FINAL_GFF"
 echo "================================================================="

--- a/predict.sh
+++ b/predict.sh
@@ -41,6 +41,10 @@ Options:
                                                 Guards against short introns being invented to step over
                                                 an in-frame stop codon. Lower it for compact genomes
                                                 with genuinely short introns.
+    --allow-u12-introns     Also allow U12-type AT-AC introns during frame-aware
+                                                decoding (default: only GT-AG/GC-AG). These are real but
+                                                rare; enabling this roughly doubles the intron state count
+                                                and slows decoding accordingly.
   -c, --cpu-workers N   CPU worker processes used in GFF export transcript grouping.
                                                 Uses an order-preserving map so outputs remain deterministic.
                                                 (default: 1)
@@ -98,6 +102,7 @@ MIN_TRANSCRIPT_LENGTH="3"
 ORF_MAX_SHIFT="300"
 FRAME_AWARE="1"
 MIN_INTRON_LENGTH="20"
+ALLOW_U12_INTRONS="0"
 CPU_WORKERS="1"
 LAUNCHER_ARG="${LAUNCHER:-}"
 MODEL_CHECKPOINT_ARG=""
@@ -114,6 +119,7 @@ while [[ $# -gt 0 ]]; do
     --orf-max-shift) ORF_MAX_SHIFT="$2"; shift 2 ;;
     --no-frame-aware) FRAME_AWARE="0"; shift ;;
     --min-intron-length) MIN_INTRON_LENGTH="$2"; shift 2 ;;
+    --allow-u12-introns) ALLOW_U12_INTRONS="1"; shift ;;
     -c|--cpu-workers) CPU_WORKERS="$2"; shift 2 ;;
     -b|--batch-size) BATCH_SIZE_ARG="$2"; shift 2 ;;
     -g|--gpus)       GPUS_ARG="$2";       shift 2 ;;
@@ -224,7 +230,7 @@ echo "Mode:        $MODE  ($BASE_MODEL + $HEAD_MODEL)"
 echo "Top contigs: $TOP_N_CONTIGS"
 echo "Min tx len:  $MIN_TRANSCRIPT_LENGTH"
 echo "ORF shift:   $ORF_MAX_SHIFT"
-echo "Frame-aware: $FRAME_AWARE (min intron $MIN_INTRON_LENGTH)"
+echo "Frame-aware: $FRAME_AWARE (min intron $MIN_INTRON_LENGTH, allow U12 introns: $ALLOW_U12_INTRONS)"
 echo "CPU workers: $CPU_WORKERS"
 echo "================================================================="
 
@@ -560,6 +566,9 @@ process_chromosome() {
 
 if [[ "$FRAME_AWARE" == "1" ]]; then
     FRAME_AWARE_ARGS=(--input-fasta "$INPUT_FILE" --min-intron-length "$MIN_INTRON_LENGTH")
+    if [[ "$ALLOW_U12_INTRONS" == "1" ]]; then
+        FRAME_AWARE_ARGS+=(--allow-u12-introns)
+    fi
 else
     FRAME_AWARE_ARGS=()
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genecad"
-version = "0.3.0"
+version = "0.4.0"
 description = "GeneCAD: A long-context genome annotation model built on PlantCAD2"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/detect_intervals.py
+++ b/scripts/detect_intervals.py
@@ -7,7 +7,11 @@ from src.sequence import (
     viterbi_decode,
 )
 from src.frame_hmm import (
+    AT_AC,
     DEFAULT_MIN_INTRON_LENGTH,
+    DEFAULT_SPLICE_MOTIF_GROUPS,
+    GT_AG,
+    SpliceMotifGroup,
     encode_sequence,
     frame_aware_decode,
     reverse_complement_codes,
@@ -40,6 +44,7 @@ def _detect_intervals(
     remove_incomplete_features: bool,
     base_codes: np.ndarray | None = None,
     min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
 ) -> xr.Dataset:
     """Infer genomic intervals from per-token feature predictions.
 
@@ -98,6 +103,7 @@ def _detect_intervals(
                 base_codes=strand_base_codes,
                 feature_transition=matrix,
                 min_intron_length=min_intron_length,
+                splice_motif_groups=splice_motif_groups,
             )
         else:
             # Decoding takes ~90 seconds for 308452471 tokens on Grace CPU
@@ -221,6 +227,7 @@ def detect_intervals(
     remove_incomplete_features: bool,
     input_fasta: str | None = None,
     min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
 ):
     """Aggregate rank outputs and decode genomic intervals from logits.
 
@@ -262,6 +269,7 @@ def detect_intervals(
         remove_incomplete_features=remove_incomplete_features,
         base_codes=base_codes,
         min_intron_length=min_intron_length,
+        splice_motif_groups=splice_motif_groups,
     )
     interval_predictions = interval_predictions.assign_attrs(
         # Copy attributes from sequence predictions, which have
@@ -369,8 +377,19 @@ def main():
         default="plant",
         help="Biological domain for Viterbi transition priors (default: plant)",
     )
+    parser.add_argument(
+        "--allow-u12-introns",
+        action="store_true",
+        help="Also allow U12-type AT-AC introns during frame-aware decoding "
+        "(default: only GT-AG/GC-AG). AT-AC introns are real but rare "
+        "(~0.04%% of introns in the TAIR12 reference); enabling this roughly "
+        "doubles the intron state count. Ignored unless --input-fasta is set.",
+    )
 
     args = parser.parse_args()
+    splice_motif_groups = (
+        (GT_AG, AT_AC) if args.allow_u12_introns else DEFAULT_SPLICE_MOTIF_GROUPS
+    )
 
     if args.manifest is None:
         if (args.input_dir is None) or (args.output_zarr is None):
@@ -390,6 +409,7 @@ def main():
             remove_incomplete_features=(not args.keep_incomplete_features),
             input_fasta=args.input_fasta,
             min_intron_length=args.min_intron_length,
+            splice_motif_groups=splice_motif_groups,
         )
     else:
         with open(args.manifest) as fh:
@@ -412,6 +432,7 @@ def main():
                 remove_incomplete_features=(not args.keep_incomplete_features),
                 input_fasta=args.input_fasta,
                 min_intron_length=args.min_intron_length,
+                splice_motif_groups=splice_motif_groups,
             )
 
 

--- a/scripts/detect_intervals.py
+++ b/scripts/detect_intervals.py
@@ -356,6 +356,7 @@ def main():
     )
     parser.add_argument(
         "--input-fasta",
+        "-f",
         type=str,
         default=None,
         help="Genome FASTA used for prediction. When given, decoding becomes "

--- a/scripts/detect_intervals.py
+++ b/scripts/detect_intervals.py
@@ -3,7 +3,14 @@ import logging
 from numpy import typing as npt
 from src.sequence import (
     convert_entity_labels_to_intervals,
+    regularize_transition_matrix,
     viterbi_decode,
+)
+from src.frame_hmm import (
+    DEFAULT_MIN_INTRON_LENGTH,
+    encode_sequence,
+    frame_aware_decode,
+    reverse_complement_codes,
 )
 import torch
 import torch.nn.functional as F
@@ -31,6 +38,8 @@ def _detect_intervals(
     intergenic_bias: float,
     domain: str,
     remove_incomplete_features: bool,
+    base_codes: np.ndarray | None = None,
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
 ) -> xr.Dataset:
     """Infer genomic intervals from per-token feature predictions.
 
@@ -56,7 +65,9 @@ def _detect_intervals(
     assert set(strands) == {"positive", "negative"}
 
     def _decode_intervals_viterbi(
-        logits: npt.ArrayLike, remove_incomplete_features: bool
+        logits: npt.ArrayLike,
+        remove_incomplete_features: bool,
+        strand_base_codes: np.ndarray | None = None,
     ) -> np.ndarray:
         transition_probs = token_transition_probs(
             remove_incomplete_features=remove_incomplete_features,
@@ -73,14 +84,29 @@ def _detect_intervals(
         assert emissions.min() >= 0 and emissions.max() <= 1
         assert transition_probs.index.tolist() == transition_probs.columns.tolist()
 
-        # Decoding takes ~90 seconds for 308452471 tokens on Grace CPU
         alpha = viterbi_alpha
-        logger.info(f"Running viterbi decoding ({alpha=})")
-        labels = viterbi_decode(
-            emission_probs=emissions,
-            transition_matrix=transition_probs.values,
-            alpha=alpha,
-        )
+        matrix = transition_probs.values
+        if strand_base_codes is not None:
+            # Regularization has to be applied to the 5x5 feature matrix before
+            # it is expanded: smoothing the expanded matrix would fill in the
+            # structural zeros that carry the reading frame.
+            if alpha is not None:
+                matrix = regularize_transition_matrix(matrix, alpha)
+            logger.info(f"Running frame-aware viterbi decoding ({alpha=})")
+            labels = frame_aware_decode(
+                feature_probs=emissions,
+                base_codes=strand_base_codes,
+                feature_transition=matrix,
+                min_intron_length=min_intron_length,
+            )
+        else:
+            # Decoding takes ~90 seconds for 308452471 tokens on Grace CPU
+            logger.info(f"Running viterbi decoding ({alpha=})")
+            labels = viterbi_decode(
+                emission_probs=emissions,
+                transition_matrix=matrix,
+                alpha=alpha,
+            )
 
         assert labels.ndim == 1
         # pyrefly: ignore  # bad-argument-type
@@ -114,12 +140,20 @@ def _detect_intervals(
                 viterbi_labels = _decode_intervals_viterbi(
                     logits=logits,
                     remove_incomplete_features=remove_incomplete_features,
+                    strand_base_codes=base_codes,
                 )
             else:
+                # The minus strand is decoded on the reversed logit array, so the
+                # sequence must be reverse complemented to stay in register.
                 viterbi_labels = flip(
                     _decode_intervals_viterbi(
                         logits=flip(logits).copy(),
                         remove_incomplete_features=remove_incomplete_features,
+                        strand_base_codes=(
+                            None
+                            if base_codes is None
+                            else reverse_complement_codes(base_codes)
+                        ),
                     )
                 )
 
@@ -148,6 +182,35 @@ def _detect_intervals(
     return region_intervals
 
 
+def load_chromosome_codes(fasta_path: str, chromosome_id: str) -> np.ndarray:
+    """Read one chromosome from a FASTA file and encode it as base codes.
+
+    The file is streamed a record at a time so that whole-genome FASTAs do not
+    have to be held in memory.
+    """
+    import gzip
+
+    opener = gzip.open if fasta_path.endswith(".gz") else open
+    with opener(fasta_path, "rt") as fh:  # pyrefly: ignore[bad-argument-type]
+        current: str | None = None
+        chunks: list[str] = []
+        for line in fh:
+            if line.startswith(">"):
+                if current == chromosome_id:
+                    break
+                current = line[1:].strip().split()[0]
+                chunks = []
+            elif current == chromosome_id:
+                chunks.append(line.strip())
+    if not chunks:
+        raise ValueError(f"Sequence {chromosome_id!r} not found in {fasta_path}")
+    logger.info(
+        f"Loaded sequence {chromosome_id!r} ({sum(len(c) for c in chunks)} bp) "
+        f"from {fasta_path}"
+    )
+    return encode_sequence("".join(chunks))
+
+
 def detect_intervals(
     input_dir: str,
     output: str,
@@ -156,6 +219,8 @@ def detect_intervals(
     intergenic_bias: float,
     domain: str,
     remove_incomplete_features: bool,
+    input_fasta: str | None = None,
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
 ):
     """Aggregate rank outputs and decode genomic intervals from logits.
 
@@ -175,6 +240,18 @@ def detect_intervals(
         drop_variables=["token_predictions", "token_logits"],
     )
 
+    base_codes = None
+    if input_fasta is not None:
+        chromosome_id = sequence_predictions.attrs["chromosome_id"]
+        base_codes = load_chromosome_codes(input_fasta, chromosome_id)
+        n_positions = sequence_predictions.sizes["sequence"]
+        if len(base_codes) != n_positions:
+            raise ValueError(
+                f"Sequence {chromosome_id!r} has {len(base_codes)} bases but "
+                f"{n_positions} positions were predicted; frame-aware decoding "
+                f"requires the FASTA used for prediction"
+            )
+
     logger.info("Detecting intervals")
     interval_predictions = _detect_intervals(
         predictions=sequence_predictions,
@@ -183,6 +260,8 @@ def detect_intervals(
         intergenic_bias=intergenic_bias,
         domain=domain,
         remove_incomplete_features=remove_incomplete_features,
+        base_codes=base_codes,
+        min_intron_length=min_intron_length,
     )
     interval_predictions = interval_predictions.assign_attrs(
         # Copy attributes from sequence predictions, which have
@@ -268,6 +347,22 @@ def main():
         help="Keep incomplete features in the prediction",
     )
     parser.add_argument(
+        "--input-fasta",
+        type=str,
+        default=None,
+        help="Genome FASTA used for prediction. When given, decoding becomes "
+        "frame-aware: the CDS is constrained to begin on ATG, end on a stop "
+        "codon, stay in frame across introns, and contain no in-frame stop. "
+        "Ignored when --decode-direct is set.",
+    )
+    parser.add_argument(
+        "--min-intron-length",
+        type=int,
+        default=DEFAULT_MIN_INTRON_LENGTH,
+        help="Shortest intron frame-aware decoding may emit. Guards against short "
+        "introns being invented to step over an in-frame stop codon.",
+    )
+    parser.add_argument(
         "--domain",
         type=str,
         choices=["plant", "animal"],
@@ -293,6 +388,8 @@ def main():
             intergenic_bias=args.intergenic_bias,
             domain=args.domain,
             remove_incomplete_features=(not args.keep_incomplete_features),
+            input_fasta=args.input_fasta,
+            min_intron_length=args.min_intron_length,
         )
     else:
         with open(args.manifest) as fh:
@@ -313,6 +410,8 @@ def main():
                 intergenic_bias=args.intergenic_bias,
                 domain=args.domain,
                 remove_incomplete_features=(not args.keep_incomplete_features),
+                input_fasta=args.input_fasta,
+                min_intron_length=args.min_intron_length,
             )
 
 

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+"""ORF-aware repair of CDS boundaries in GeneCAD predictions.
+
+GeneCAD decodes per-base feature labels (intergenic / intron / 5'UTR / CDS /
+3'UTR) and never reads the underlying nucleotide sequence, so a predicted CDS
+is not guaranteed to be a translatable ORF: it may not start on ATG, may not
+end on a stop codon, may not be a multiple of three, or may carry an in-frame
+stop.  This step repairs those models using the genome sequence.
+
+The repair is deliberately constrained so that it cannot invent gene structure:
+
+1.  Exon structure is frozen.  Exons are derived by merging *contiguous*
+    predicted features (CDS / 5'UTR / 3'UTR); every remaining gap is an intron
+    and is never moved, split, merged or created.  Consequently every splice
+    junction in the output is a junction the model itself predicted.
+2.  Only the TIS and the TTS move, and they move *within the spliced mRNA* —
+    i.e. only across sequence the model already called exonic.  A repair can
+    therefore only relabel predicted UTR as CDS or predicted CDS as UTR; it can
+    never pull in intronic or intergenic sequence.
+3.  Internal introns must be canonical (GT-AG / GC-AG / AT-AC) for a repair to
+    be attempted.  If the model's own splice calls are not trustworthy, neither
+    is any ORF built on top of them.  (Relax with --allow-noncanonical-introns.)
+4.  The repaired ORF must be fully valid: ATG start, length % 3 == 0, no
+    in-frame stop, stop codon end.
+5.  Among valid solutions the one closest to the original prediction wins
+    (minimum total boundary movement), and movement is capped by --max-shift.
+    Truncating a long CDS down to a short ORF is therefore rejected: it would
+    require a large 3' shift.
+
+Transcripts that cannot be repaired under these rules are *not* forced into an
+ORF.  They are passed through unchanged and flagged (partial=true, orf_issue=…,
+plus GFF3 start_range / end_range) so downstream steps can filter them.
+
+Usage
+-----
+    python scripts/fix_orf.py -i raw.gff -f genome.fa -o fixed.gff \\
+        [--report status.tsv] [--max-shift 300]
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import logging
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+STOP_CODONS = frozenset(("TAA", "TAG", "TGA"))
+START_CODON = "ATG"
+
+# Canonical intron donor/acceptor dinucleotide pairs, read 5'->3' on the
+# transcribed strand.  GT-AG and GC-AG are U2-type; AT-AC is U12-type.
+CANONICAL_SPLICE_PAIRS = frozenset((("GT", "AG"), ("GC", "AG"), ("AT", "AC")))
+
+CDS = "CDS"
+FIVE_PRIME_UTR = "five_prime_UTR"
+THREE_PRIME_UTR = "three_prime_UTR"
+MRNA = "mRNA"
+GENE = "gene"
+
+EXONIC_TYPES = (CDS, FIVE_PRIME_UTR, THREE_PRIME_UTR)
+
+COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANtgcan")
+
+
+def revcomp(seq: str) -> str:
+    return seq.translate(COMPLEMENT)[::-1]
+
+
+# -------------------------------------------------------------------------------------------------
+# GFF records
+# -------------------------------------------------------------------------------------------------
+
+
+@dataclass
+class Record:
+    """A single GFF3 feature line, kept in a mutable form."""
+
+    seqid: str
+    source: str
+    type: str
+    start: int  # 1-based inclusive
+    end: int  # 1-based inclusive
+    score: str
+    strand: str
+    phase: str
+    attributes: dict[str, str]
+    order: int  # original line number, used to preserve output ordering
+
+    @property
+    def id(self) -> str | None:
+        return self.attributes.get("ID")
+
+    @property
+    def parent(self) -> str | None:
+        return self.attributes.get("Parent")
+
+    def to_line(self) -> str:
+        attrs = ";".join(f"{k}={v}" for k, v in self.attributes.items())
+        return "\t".join(
+            [
+                self.seqid,
+                self.source,
+                self.type,
+                str(self.start),
+                str(self.end),
+                self.score,
+                self.strand,
+                self.phase,
+                attrs if attrs else ".",
+            ]
+        )
+
+
+def parse_attributes(text: str) -> dict[str, str]:
+    attrs: dict[str, str] = {}
+    if text in (".", ""):
+        return attrs
+    for part in text.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        key, sep, value = part.partition("=")
+        if sep:
+            attrs[key] = value
+    return attrs
+
+
+def read_gff(path: str) -> tuple[list[str], list[Record]]:
+    """Read a GFF3 file into a header block and a list of records."""
+    header: list[str] = []
+    records: list[Record] = []
+    opener = gzip.open if path.endswith(".gz") else open
+    with opener(path, "rt") as fh:  # pyrefly: ignore[bad-argument-type]
+        for order, line in enumerate(fh):
+            if line.startswith("#"):
+                # Only keep header comments that precede the first feature
+                if not records:
+                    header.append(line.rstrip("\n"))
+                continue
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            fields = line.split("\t")
+            if len(fields) != 9:
+                logger.warning(f"Skipping malformed line {order + 1}: {line[:80]!r}")
+                continue
+            records.append(
+                Record(
+                    seqid=fields[0],
+                    source=fields[1],
+                    type=fields[2],
+                    start=int(fields[3]),
+                    end=int(fields[4]),
+                    score=fields[5],
+                    strand=fields[6],
+                    phase=fields[7],
+                    attributes=parse_attributes(fields[8]),
+                    order=order,
+                )
+            )
+    if not header:
+        header = ["##gff-version 3"]
+    return header, records
+
+
+# -------------------------------------------------------------------------------------------------
+# Transcript model
+# -------------------------------------------------------------------------------------------------
+
+
+@dataclass
+class Transcript:
+    """An mRNA plus its exonic children, indexed for coordinate conversion."""
+
+    mrna: Record
+    children: list[Record]
+    seqid: str
+    strand: str
+    # Exons in 5'->3' coding order as 1-based inclusive genomic (start, end)
+    exons: list[tuple[int, int]] = field(default_factory=list)
+    # Transcript-coordinate offset at which each exon begins
+    exon_offsets: list[int] = field(default_factory=list)
+    length: int = 0
+
+    def build_exons(self) -> None:
+        """Merge contiguous exonic features into exons, ordered 5'->3'."""
+        blocks = sorted(
+            (r.start, r.end) for r in self.children if r.type in EXONIC_TYPES
+        )
+        merged: list[tuple[int, int]] = []
+        for start, end in blocks:
+            if merged and start <= merged[-1][1] + 1:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        if self.strand == "-":
+            merged.reverse()
+        self.exons = merged
+        offsets: list[int] = []
+        total = 0
+        for start, end in merged:
+            offsets.append(total)
+            total += end - start + 1
+        self.exon_offsets = offsets
+        self.length = total
+
+    def genomic_to_transcript(self, pos: int) -> int | None:
+        """Convert a 1-based genomic position to a 0-based transcript offset."""
+        for (start, end), offset in zip(self.exons, self.exon_offsets):
+            if start <= pos <= end:
+                return offset + (pos - start if self.strand == "+" else end - pos)
+        return None
+
+    def transcript_to_blocks(self, begin: int, stop: int) -> list[tuple[int, int]]:
+        """Map a half-open transcript interval to 1-based inclusive genomic blocks.
+
+        Blocks are returned in ascending genomic order.
+        """
+        blocks: list[tuple[int, int]] = []
+        if begin >= stop:
+            return blocks
+        for (gstart, gend), offset in zip(self.exons, self.exon_offsets):
+            exon_len = gend - gstart + 1
+            lo = max(begin, offset)
+            hi = min(stop, offset + exon_len)
+            if lo >= hi:
+                continue
+            a, b = lo - offset, hi - offset  # offsets within the exon, half-open
+            if self.strand == "+":
+                blocks.append((gstart + a, gstart + b - 1))
+            else:
+                blocks.append((gend - b + 1, gend - a))
+        blocks.sort()
+        return blocks
+
+    def spliced_sequence(self, chrom: str) -> str:
+        """Extract the spliced mRNA sequence in coding orientation.
+
+        ``self.exons`` is stored in 5'->3' coding order, so on the minus strand
+        it runs in descending genomic order.  Splicing must be done in ascending
+        genomic order before reverse complementing, since
+        ``revcomp(a + b) == revcomp(b) + revcomp(a)`` would otherwise reverse the
+        exon order a second time.
+        """
+        ordered = self.exons if self.strand == "+" else self.exons[::-1]
+        seq = "".join(chrom[start - 1 : end] for start, end in ordered).upper()
+        return seq if self.strand == "+" else revcomp(seq)
+
+    def introns(self) -> list[tuple[int, int]]:
+        """Introns as 1-based inclusive genomic (start, end), 5'->3' coding order."""
+        result: list[tuple[int, int]] = []
+        for first, second in zip(self.exons, self.exons[1:]):
+            if self.strand == "+":
+                result.append((first[1] + 1, second[0] - 1))
+            else:
+                result.append((second[1] + 1, first[0] - 1))
+        return result
+
+
+# -------------------------------------------------------------------------------------------------
+# ORF logic
+# -------------------------------------------------------------------------------------------------
+
+
+def has_internal_stop(seq: str, begin: int, stop: int) -> bool:
+    """True if seq[begin:stop] contains an in-frame stop codon before its last codon."""
+    return any(seq[i : i + 3] in STOP_CODONS for i in range(begin, stop - 3, 3))
+
+
+def is_complete_orf(seq: str, begin: int, stop: int, min_protein_length: int) -> bool:
+    length = stop - begin
+    if length % 3 != 0 or length < 3 * (min_protein_length + 1):
+        return False
+    if seq[begin : begin + 3] != START_CODON:
+        return False
+    if seq[stop - 3 : stop] not in STOP_CODONS:
+        return False
+    return not has_internal_stop(seq, begin, stop)
+
+
+def build_next_in_frame_stop(seq: str) -> list[int]:
+    """For each offset i, the offset of the first in-frame stop codon at or after i.
+
+    Returns -1 where no in-frame stop exists.  Computed in O(len(seq)) by
+    scanning backwards within each of the three reading frames.
+    """
+    n = len(seq)
+    next_stop = [-1] * (n + 1)
+    for start in range(max(n - 2, 0), -1, -1):
+        nxt = next_stop[start + 3] if start + 3 <= n else -1
+        next_stop[start] = start if seq[start : start + 3] in STOP_CODONS else nxt
+    return next_stop
+
+
+def find_best_orf(
+    seq: str,
+    cds_begin: int,
+    cds_stop: int,
+    max_shift: int | None,
+    min_protein_length: int,
+) -> tuple[int, int] | None:
+    """Find the valid ORF whose boundaries move least from (cds_begin, cds_stop).
+
+    Given a start offset the ORF end is forced: it must terminate at the *first*
+    in-frame stop, otherwise the ORF would contain an internal stop.  The search
+    is therefore one-dimensional over candidate ATG positions.
+
+    Parameters
+    ----------
+    seq
+        Spliced mRNA sequence in coding orientation.
+    cds_begin, cds_stop
+        Half-open transcript interval of the predicted CDS.
+    max_shift
+        Maximum allowed movement of either boundary, or None for unbounded
+        (used to distinguish "no ORF at all" from "ORF outside the window").
+    min_protein_length
+        Minimum protein length in residues, excluding the stop codon.
+
+    Returns
+    -------
+    tuple[int, int] | None
+        Half-open transcript interval of the best ORF, or None.
+    """
+    next_stop = build_next_in_frame_stop(seq)
+    if max_shift is None:
+        lo, hi = 0, len(seq)
+    else:
+        lo = max(0, cds_begin - max_shift)
+        hi = min(len(seq), cds_begin + max_shift + 1)
+
+    best: tuple[int, int] | None = None
+    best_key: tuple[int, int, int] | None = None
+    for begin in range(lo, hi):
+        if seq[begin : begin + 3] != START_CODON:
+            continue
+        stop_offset = next_stop[begin]
+        if stop_offset < 0:
+            continue
+        stop = stop_offset + 3
+        if stop - begin < 3 * (min_protein_length + 1):
+            continue
+        if max_shift is not None and abs(stop - cds_stop) > max_shift:
+            continue
+        # Prefer the smallest total boundary movement; break ties toward the
+        # longer ORF, then toward the smaller start offset, for determinism.
+        cost = abs(begin - cds_begin) + abs(stop - cds_stop)
+        key = (cost, -(stop - begin), begin)
+        if best_key is None or key < best_key:
+            best_key, best = key, (begin, stop)
+    return best
+
+
+# -------------------------------------------------------------------------------------------------
+# Repair
+# -------------------------------------------------------------------------------------------------
+
+
+@dataclass
+class Result:
+    status: str
+    issue: str = ""
+    shift5: int = 0
+    shift3: int = 0
+    missing_start: bool = False
+    missing_stop: bool = False
+
+
+def rebuild_children(
+    transcript: Transcript, begin: int, stop: int, source_records: list[Record]
+) -> list[Record]:
+    """Regenerate CDS and UTR records for a new CDS interval in transcript coords."""
+    mrna_id = transcript.mrna.id or ""
+    template = source_records[0]
+    order = min(r.order for r in source_records)
+
+    spans = [
+        (FIVE_PRIME_UTR, transcript.transcript_to_blocks(0, begin)),
+        (CDS, transcript.transcript_to_blocks(begin, stop)),
+        (THREE_PRIME_UTR, transcript.transcript_to_blocks(stop, transcript.length)),
+    ]
+
+    # GFF3 phase: number of bases to remove from the start of a CDS feature to
+    # reach the first complete codon, accumulated in 5'->3' coding order.
+    cds_blocks = spans[1][1]
+    coding_order = sorted(cds_blocks, reverse=(transcript.strand == "-"))
+    phases: dict[tuple[int, int], int] = {}
+    cumulative = 0
+    for block in coding_order:
+        phases[block] = (-cumulative) % 3
+        cumulative += block[1] - block[0] + 1
+
+    records: list[Record] = []
+    for feature_type, blocks in spans:
+        for index, (start, end) in enumerate(blocks, start=1):
+            records.append(
+                Record(
+                    seqid=transcript.seqid,
+                    source=template.source,
+                    type=feature_type,
+                    start=start,
+                    end=end,
+                    score=template.score,
+                    strand=transcript.strand,
+                    phase=str(phases[(start, end)]) if feature_type == CDS else ".",
+                    attributes={
+                        "ID": f"{mrna_id}.{feature_type}.{index}",
+                        "Parent": mrna_id,
+                    },
+                    order=order,
+                )
+            )
+    records.sort(key=lambda r: (r.start, r.end))
+    return records
+
+
+def repair_transcript(
+    transcript: Transcript,
+    chrom: str,
+    max_shift: int,
+    min_protein_length: int,
+    require_canonical: bool,
+) -> tuple[Result, list[Record] | None]:
+    """Evaluate and, if needed and possible, repair one transcript's CDS."""
+    cds_records = [r for r in transcript.children if r.type == CDS]
+    if not cds_records:
+        return Result("skipped", "no_cds"), None
+
+    transcript.build_exons()
+    if transcript.length == 0:
+        return Result("skipped", "no_exons"), None
+
+    seq = transcript.spliced_sequence(chrom)
+    if len(seq) != transcript.length:
+        return Result("skipped", "sequence_length_mismatch"), None
+
+    # Locate the predicted CDS in transcript coordinates.
+    coding_first = min(r.start for r in cds_records)
+    coding_last = max(r.end for r in cds_records)
+    if transcript.strand == "+":
+        begin = transcript.genomic_to_transcript(coding_first)
+        stop_inclusive = transcript.genomic_to_transcript(coding_last)
+    else:
+        begin = transcript.genomic_to_transcript(coding_last)
+        stop_inclusive = transcript.genomic_to_transcript(coding_first)
+    if begin is None or stop_inclusive is None:
+        return Result("skipped", "cds_outside_exons"), None
+    stop = stop_inclusive + 1
+
+    cds_length = sum(r.end - r.start + 1 for r in cds_records)
+    if stop - begin != cds_length:
+        # The predicted CDS is not contiguous within the spliced transcript,
+        # which means UTR was called between two CDS blocks.  Repairing that
+        # would require changing the model's own feature layout.
+        return Result("partial", "discontiguous_cds"), None
+
+    missing_start = seq[begin : begin + 3] != START_CODON
+    missing_stop = seq[stop - 3 : stop] not in STOP_CODONS
+    ambiguous = "N" in seq[begin:stop]
+
+    if not ambiguous and is_complete_orf(seq, begin, stop, min_protein_length):
+        return Result("complete"), None
+
+    if "N" in seq:
+        # An ORF cannot be verified across an assembly gap, and picking a start
+        # or stop codon adjacent to one would be guesswork.
+        return (
+            Result(
+                "partial",
+                "ambiguous_bases",
+                missing_start=missing_start,
+                missing_stop=missing_stop,
+            ),
+            None,
+        )
+
+    # Introns must be trustworthy before an ORF is built on top of them.
+    noncanonical = 0
+    for intron_start, intron_end in transcript.introns():
+        if intron_end < intron_start:
+            noncanonical += 1
+            continue
+        donor = chrom[intron_start - 1 : intron_start + 1].upper()
+        acceptor = chrom[intron_end - 2 : intron_end].upper()
+        if transcript.strand == "-":
+            donor, acceptor = revcomp(acceptor), revcomp(donor)
+        if (donor, acceptor) not in CANONICAL_SPLICE_PAIRS:
+            noncanonical += 1
+    if noncanonical and require_canonical:
+        return (
+            Result(
+                "partial",
+                "noncanonical_intron",
+                missing_start=missing_start,
+                missing_stop=missing_stop,
+            ),
+            None,
+        )
+
+    orf = find_best_orf(seq, begin, stop, max_shift, min_protein_length)
+    if orf is None:
+        # Distinguish "structurally impossible" from "outside the search window"
+        # so the two failure modes can be triaged separately.
+        unbounded = find_best_orf(seq, begin, stop, None, min_protein_length)
+        issue = "no_orf_in_transcript" if unbounded is None else "orf_outside_window"
+        return (
+            Result(
+                "partial",
+                issue,
+                missing_start=missing_start,
+                missing_stop=missing_stop,
+            ),
+            None,
+        )
+
+    new_begin, new_stop = orf
+    records = rebuild_children(transcript, new_begin, new_stop, transcript.children)
+    return Result("repaired", shift5=new_begin - begin, shift3=new_stop - stop), records
+
+
+# -------------------------------------------------------------------------------------------------
+# Driver
+# -------------------------------------------------------------------------------------------------
+
+
+def iter_fasta(path: str):
+    """Yield (seqid, sequence) pairs, one chromosome at a time."""
+    opener = gzip.open if path.endswith(".gz") else open
+    with opener(path, "rt") as fh:  # pyrefly: ignore[bad-argument-type]
+        seqid: str | None = None
+        chunks: list[str] = []
+        for line in fh:
+            if line.startswith(">"):
+                if seqid is not None:
+                    yield seqid, "".join(chunks)
+                seqid = line[1:].strip().split()[0]
+                chunks = []
+            else:
+                chunks.append(line.strip())
+        if seqid is not None:
+            yield seqid, "".join(chunks)
+
+
+def fix_orf(
+    input_gff: str,
+    input_fasta: str,
+    output_gff: str,
+    max_shift: int,
+    min_protein_length: int,
+    require_canonical: bool,
+    report_path: str | None,
+) -> Counter:
+    logger.info(f"Reading GFF {input_gff}")
+    header, records = read_gff(input_gff)
+    logger.info(f"Read {len(records)} records")
+
+    by_id = {r.id: r for r in records if r.id}
+    children_by_parent: dict[str, list[Record]] = defaultdict(list)
+    for record in records:
+        if record.parent:
+            children_by_parent[record.parent].append(record)
+
+    transcripts: dict[str, Transcript] = {}
+    for record in records:
+        if record.type != MRNA or not record.id:
+            continue
+        transcripts[record.id] = Transcript(
+            mrna=record,
+            children=children_by_parent.get(record.id, []),
+            seqid=record.seqid,
+            strand=record.strand,
+        )
+    logger.info(f"Found {len(transcripts)} transcripts")
+
+    by_seqid: dict[str, list[Transcript]] = defaultdict(list)
+    for transcript in transcripts.values():
+        by_seqid[transcript.seqid].append(transcript)
+
+    stats: Counter = Counter()
+    shift_hist: Counter = Counter()
+    results: dict[str, Result] = {}
+    replacements: dict[str, list[Record]] = {}
+    seen_seqids: set[str] = set()
+
+    for seqid, chrom in iter_fasta(input_fasta):
+        if seqid not in by_seqid:
+            continue
+        seen_seqids.add(seqid)
+        logger.info(f"Processing {seqid} ({len(by_seqid[seqid])} transcripts)")
+        for transcript in by_seqid[seqid]:
+            result, new_records = repair_transcript(
+                transcript,
+                chrom,
+                max_shift=max_shift,
+                min_protein_length=min_protein_length,
+                require_canonical=require_canonical,
+            )
+            mrna_id = transcript.mrna.id or ""
+            results[mrna_id] = result
+            stats[result.status] += 1
+            if result.issue:
+                stats[f"issue:{result.issue}"] += 1
+            if new_records is not None:
+                replacements[mrna_id] = new_records
+                shift_hist[(result.shift5, result.shift3)] += 1
+
+    missing = set(by_seqid) - seen_seqids
+    if missing:
+        logger.warning(
+            f"{len(missing)} sequence(s) in the GFF were absent from the FASTA and "
+            f"were left untouched, e.g. {sorted(missing)[:5]}"
+        )
+        for seqid in missing:
+            for transcript in by_seqid[seqid]:
+                results[transcript.mrna.id or ""] = Result("skipped", "no_sequence")
+                stats["skipped"] += 1
+                stats["issue:no_sequence"] += 1
+
+    # ---------------------------------------------------------------------
+    # Annotate and write
+    # ---------------------------------------------------------------------
+    for mrna_id, result in results.items():
+        mrna = transcripts[mrna_id].mrna
+        mrna.attributes["orf_status"] = result.status
+        if result.status == "repaired":
+            mrna.attributes["orf_shift_5"] = str(result.shift5)
+            mrna.attributes["orf_shift_3"] = str(result.shift3)
+        if result.issue:
+            mrna.attributes["orf_issue"] = result.issue
+        if result.status == "partial":
+            mrna.attributes["partial"] = "true"
+            if result.missing_start:
+                mrna.attributes["start_range"] = f".,{mrna.start}"
+            if result.missing_stop:
+                mrna.attributes["end_range"] = f"{mrna.end},."
+            parent = by_id.get(mrna.parent or "")
+            if parent is not None and parent.type == GENE:
+                parent.attributes["partial"] = "true"
+
+    output: list[Record] = []
+    replaced_parents = set(replacements)
+    for record in records:
+        if record.parent in replaced_parents and record.type in EXONIC_TYPES:
+            continue  # superseded by regenerated features
+        output.append(record)
+    for mrna_id, new_records in replacements.items():
+        output.extend(new_records)
+
+    # Preserve the input's gene-by-gene layout: sort by original position, and
+    # place regenerated children immediately after the mRNA they belong to.
+    output.sort(key=lambda r: (r.order, r.start, r.end, r.type))
+
+    logger.info(f"Writing {len(output)} records to {output_gff}")
+    with open(output_gff, "w") as fh:
+        for line in header:
+            fh.write(line + "\n")
+        for record in output:
+            fh.write(record.to_line() + "\n")
+
+    if report_path:
+        logger.info(f"Writing per-transcript report to {report_path}")
+        with open(report_path, "w") as fh:
+            fh.write("transcript_id\tseqid\tstrand\tstatus\tissue\tshift_5\tshift_3\n")
+            for mrna_id, result in sorted(results.items()):
+                transcript = transcripts[mrna_id]
+                fh.write(
+                    f"{mrna_id}\t{transcript.seqid}\t{transcript.strand}\t"
+                    f"{result.status}\t{result.issue}\t{result.shift5}\t{result.shift3}\n"
+                )
+
+    # ---------------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------------
+    total = sum(stats[k] for k in ("complete", "repaired", "partial", "skipped"))
+    logger.info("=" * 68)
+    logger.info(f"ORF repair summary ({total} transcripts)")
+    for status in ("complete", "repaired", "partial", "skipped"):
+        count = stats[status]
+        logger.info(f"  {status:10s} {count:8d}  {100 * count / max(total, 1):5.1f}%")
+    valid = stats["complete"] + stats["repaired"]
+    logger.info(
+        f"  complete ORFs: {stats['complete']} -> {valid} "
+        f"({100 * stats['complete'] / max(total, 1):.1f}% -> "
+        f"{100 * valid / max(total, 1):.1f}%)"
+    )
+    issues = {k[6:]: v for k, v in stats.items() if k.startswith("issue:")}
+    if issues:
+        logger.info("  unrepaired, by reason:")
+        for reason, count in sorted(issues.items(), key=lambda kv: -kv[1]):
+            logger.info(f"    {reason:24s} {count:8d}")
+    if shift_hist:
+        shifts = [abs(a) + abs(b) for (a, b), n in shift_hist.items() for _ in range(n)]
+        shifts.sort()
+        logger.info(
+            f"  repair boundary movement (nt): median={shifts[len(shifts) // 2]}, "
+            f"p90={shifts[int(len(shifts) * 0.9)]}, max={shifts[-1]}"
+        )
+    logger.info("=" * 68)
+    return stats
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
+    parser = argparse.ArgumentParser(
+        description="Repair CDS boundaries in GeneCAD predictions so they form valid ORFs.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--input-gff", "-i", required=True, help="Input GFF3 file")
+    parser.add_argument("--input-fasta", "-f", required=True, help="Genome FASTA file")
+    parser.add_argument("--output-gff", "-o", required=True, help="Output GFF3 file")
+    parser.add_argument(
+        "--max-shift",
+        type=int,
+        default=300,
+        help="Maximum movement (nt, in spliced transcript coordinates) allowed for "
+        "the TIS and for the TTS. Bounds how far a repair may depart from the "
+        "model's prediction, and prevents long CDS being truncated to short ORFs.",
+    )
+    parser.add_argument(
+        "--min-protein-length",
+        type=int,
+        default=10,
+        help="Minimum protein length in residues (excluding the stop codon) for a repair",
+    )
+    parser.add_argument(
+        "--allow-noncanonical-introns",
+        action="store_true",
+        help="Attempt repair even when the transcript has non-canonical introns. "
+        "Off by default: an ORF built on untrustworthy splice calls is not trustworthy.",
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="Optional TSV path for per-transcript status output",
+    )
+    args = parser.parse_args()
+
+    fix_orf(
+        input_gff=args.input_gff,
+        input_fasta=args.input_fasta,
+        output_gff=args.output_gff,
+        max_shift=args.max_shift,
+        min_protein_length=args.min_protein_length,
+        require_canonical=not args.allow_noncanonical_introns,
+        report_path=args.report,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_release.sh
+++ b/scripts/install_release.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Usage:
 #   bash scripts/install_release.sh
 # Optional env vars:
-#   GENECAD_VERSION=0.3.0
+#   GENECAD_VERSION=0.4.0
 #   PYTORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu128
 
-GENECAD_VERSION="${GENECAD_VERSION:-0.3.0}"
+GENECAD_VERSION="${GENECAD_VERSION:-0.4.0}"
 PYTORCH_CUDA_INDEX="${PYTORCH_CUDA_INDEX:-https://download.pytorch.org/whl/cu128}"
 WHEEL_URL="https://github.com/plantcad/genecad/releases/download/v${GENECAD_VERSION}/genecad-${GENECAD_VERSION}-py3-none-any.whl"
 

--- a/src/frame_hmm.py
+++ b/src/frame_hmm.py
@@ -1,0 +1,682 @@
+"""Frame-aware, sequence-constrained HMM decoding of per-base feature predictions.
+
+The default decoder in :mod:`scripts.detect_intervals` runs Viterbi over the five
+modelling features (intergenic / intron / 5' UTR / CDS / 3' UTR) and never looks
+at the genome.  It therefore has no way to express the constraints that make a
+CDS translatable, and routinely emits coding regions that are not a multiple of
+three, do not begin on ATG, do not end on a stop codon, or contain an in-frame
+stop.
+
+This module replaces that 5-state chain with an expanded state space in which
+those constraints are structural: any path the decoder is *able* to take yields
+a valid ORF.  Each expanded state carries
+
+  * the modelling feature it emits (so decoding output stays a 0-4 feature label
+    array and the rest of the pipeline is unchanged),
+  * its codon position, so reading frame is tracked across introns, and
+  * a hard constraint on the base at that position.
+
+Because every constraint is a per-base test, it stays correct when an intron
+interrupts a codon: the frame is carried by the state, not by genomic adjacency.
+
+State space
+-----------
+Stop codons are excluded by tracking the codon prefix.  A stop codon is TAA, TAG
+or TGA, so only a leading ``T`` can begin one.  Codon position 0 splits on
+"is this base a T", position 1 splits on which stop prefix (``TA`` / ``TG``) is
+live, and position 2 then forbids exactly the bases that would complete a stop.
+Introns are likewise split by which coding state they must resume into, so a
+codon may be interrupted at any of its three positions without losing frame.
+
+The start codon and the terminal stop codon get dedicated states, which is what
+lets the decoder require ATG at the beginning of the CDS and a stop codon at its
+end.  Introns are not permitted to interrupt the start or the stop codon itself;
+this occurs in real genes but is rare, and supporting it would roughly double the
+state count.
+
+Introns additionally carry their donor and acceptor dinucleotides as states, so
+every emitted intron is canonical (GT-AG or GC-AG).  That constraint is load
+bearing rather than decorative: given only the frame constraints, the cheapest
+way for the decoder to escape an in-frame stop codon is to invent a two-base
+intron across it, and measured on real predictions it did so readily.
+
+Transition probabilities are derived mechanically from the same 5x5 feature
+matrix the existing decoder uses (:func:`src.modeling.token_transition_probs`),
+so the learned feature-level statistics are preserved and only the structure is
+new.
+
+A canonical donor is not by itself enough, because GT...AG turns up by chance
+every few hundred bases, so each intron also carries a run of mandatory body
+states that impose a minimum length.  These forced states have a single
+predecessor each, so they cost states but no back-pointer memory (see
+:class:`PredecessorIndex`); per-position memory is set by the number of
+*branching* states, which does not change with the minimum length.
+
+Known limitations
+-----------------
+* U12-type AT-AC introns (~0.1-0.3% of introns) cannot be represented.
+* Introns are not permitted to interrupt the start or the stop codon.
+* Genes must have both a 5' and a 3' UTR, as in the unconstrained decoder.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import numpy as np
+from numba import njit
+from numpy import typing as npt
+
+logger = logging.getLogger(__name__)
+
+# Feature indices, matching src.schema.SEQUENCE_MODELING_FEATURES
+IG, IN, U5, CDS, U3 = range(5)
+N_FEATURES = 5
+
+# Base codes produced by `encode_sequence`
+BASE_A, BASE_C, BASE_G, BASE_T, BASE_OTHER = range(5)
+N_BASE_CODES = 5
+
+# Per-base constraint codes
+MASK_ANY = 0
+MASK_IS_A = 1
+MASK_IS_G = 2
+MASK_IS_T = 3
+MASK_NOT_T = 4
+MASK_NOT_A = 5
+MASK_NOT_AG = 6
+MASK_IS_AG = 7
+MASK_IS_TC = 8
+N_MASKS = 9
+
+# A large finite stand-in for -inf, so that adding two of them cannot produce NaN
+NEG_INF = -1e30
+
+
+def build_mask_table() -> np.ndarray:
+    """Boolean table of shape (N_MASKS, N_BASE_CODES): is this base allowed?
+
+    An ambiguous base satisfies negative constraints ("not A") but never a
+    positive one ("is A"), so an N can sit inside a CDS but can never be taken
+    as part of a start or stop codon, and never forces an in-frame stop.
+    """
+    table = np.zeros((N_MASKS, N_BASE_CODES), dtype=np.bool_)
+    table[MASK_ANY, :] = True
+    table[MASK_IS_A, BASE_A] = True
+    table[MASK_IS_G, BASE_G] = True
+    table[MASK_IS_T, BASE_T] = True
+    table[MASK_NOT_T, :] = True
+    table[MASK_NOT_T, BASE_T] = False
+    table[MASK_NOT_A, :] = True
+    table[MASK_NOT_A, BASE_A] = False
+    table[MASK_NOT_AG, :] = True
+    table[MASK_NOT_AG, BASE_A] = False
+    table[MASK_NOT_AG, BASE_G] = False
+    table[MASK_IS_AG, BASE_A] = True
+    table[MASK_IS_AG, BASE_G] = True
+    table[MASK_IS_TC, BASE_T] = True
+    table[MASK_IS_TC, BASE_C] = True
+    return table
+
+
+@dataclass(frozen=True)
+class State:
+    name: str
+    feature: int
+    mask: int
+
+
+# fmt: off
+CORE_STATES: list[State] = [
+    State("intergenic",      IG,  MASK_ANY),
+    State("utr5",            U5,  MASK_ANY),
+
+    # Start codon: A-T-G
+    State("start_a",         CDS, MASK_IS_A),
+    State("start_t",         CDS, MASK_IS_T),
+    State("start_g",         CDS, MASK_IS_G),
+
+    # CDS body.  Codon position 0 splits on "could this begin a stop codon".
+    State("cds_p0_t",        CDS, MASK_IS_T),     # prefix so far: T
+    State("cds_p0_x",        CDS, MASK_NOT_T),    # prefix so far: not a stop
+    # Codon position 1: which stop prefix, if any, is still live.
+    State("cds_p1_ta",       CDS, MASK_IS_A),     # TA_
+    State("cds_p1_tg",       CDS, MASK_IS_G),     # TG_
+    State("cds_p1_safe_t",   CDS, MASK_NOT_AG),   # T but not TA/TG
+    State("cds_p1_safe_x",   CDS, MASK_ANY),      # did not start with T
+    # Codon position 2: forbid exactly the bases completing a stop codon.
+    State("cds_p2_ta",       CDS, MASK_NOT_AG),   # forbids TAA, TAG
+    State("cds_p2_tg",       CDS, MASK_NOT_A),    # forbids TGA
+    State("cds_p2_safe",     CDS, MASK_ANY),
+
+    # Terminal stop codon: T-[AG]-x, completing TAA / TAG / TGA
+    State("stop_t",          CDS, MASK_IS_T),
+    State("stop_a",          CDS, MASK_IS_A),     # TA_
+    State("stop_g",          CDS, MASK_IS_G),     # TG_
+    State("stop_end_a",      CDS, MASK_IS_AG),    # TAA / TAG
+    State("stop_end_g",      CDS, MASK_IS_A),     # TGA
+
+    State("utr3",            U3,  MASK_ANY),
+]
+# fmt: on
+
+# Introns, one class per coding state they must resume into so that the reading
+# frame survives them.  Each class becomes a chain of states (see
+# `intron_chain_parts`) that forces a canonical donor and acceptor and a minimum
+# length.  This is not cosmetic: without it the decoder dodges an in-frame stop
+# codon by inventing a short "intron" across it, and it does so readily.
+INTRON_CLASSES: list[tuple[str, tuple[str, ...]]] = [
+    ("utr5", ("utr5", "start_a")),
+    ("p0t", ("cds_p1_ta", "cds_p1_tg", "cds_p1_safe_t")),
+    ("p0x", ("cds_p1_safe_x",)),
+    ("p1ta", ("cds_p2_ta",)),
+    ("p1tg", ("cds_p2_tg",)),
+    ("p1safe", ("cds_p2_safe",)),
+    ("p2", ("cds_p0_t", "cds_p0_x", "stop_t")),
+    ("utr3", ("utr3",)),
+]
+
+# The donor and acceptor account for four bases; a minimum-length intron also
+# needs at least one body base, so this is the shortest intron representable.
+STRUCTURAL_MIN_INTRON_LENGTH = 5
+
+# In the TAIR12 chr4 reference only 0.07% of introns are shorter than 20 nt,
+# while an unconstrained frame-aware decoder emits ~0.4% -- the excess being
+# short introns invented to step over an in-frame stop codon.  Twenty is short
+# enough to keep essentially every real intron and long enough to close that gap.
+DEFAULT_MIN_INTRON_LENGTH = 20
+
+
+def intron_chain_parts(min_intron_length: int) -> list[tuple[str, int]]:
+    """(suffix, base constraint) for the states of one intron chain.
+
+    ``b1..bk`` are mandatory body positions that impose the minimum length; the
+    looping ``body`` state that follows is what actually absorbs intron length.
+    """
+    if min_intron_length < STRUCTURAL_MIN_INTRON_LENGTH:
+        raise ValueError(
+            f"min_intron_length must be at least {STRUCTURAL_MIN_INTRON_LENGTH}; "
+            f"got {min_intron_length}"
+        )
+    mandatory = min_intron_length - STRUCTURAL_MIN_INTRON_LENGTH
+    return (
+        [("d1", MASK_IS_G), ("d2", MASK_IS_TC)]  # donor: GT or GC
+        + [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)]
+        + [("body", MASK_ANY)]
+        + [("a1", MASK_IS_A), ("a2", MASK_IS_G)]  # acceptor: AG
+    )
+
+
+def intron_state(intron_class: str, part: str) -> str:
+    return f"intron_{intron_class}_{part}"
+
+
+def build_states(min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH) -> list[State]:
+    states = list(CORE_STATES)
+    for intron_class, _ in INTRON_CLASSES:
+        for part, mask in intron_chain_parts(min_intron_length):
+            states.append(State(intron_state(intron_class, part), IN, mask))
+    return states
+
+
+MIN_INTRON_LENGTH = DEFAULT_MIN_INTRON_LENGTH
+STATES: list[State] = build_states()
+STATE_INDEX = {state.name: i for i, state in enumerate(STATES)}
+N_STATES = len(STATES)
+
+
+def build_edges(
+    feature_probs: np.ndarray,
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+) -> list[tuple[int, int, float]]:
+    """Expand the 5x5 feature transition matrix into the frame-aware state graph.
+
+    Returns a list of ``(source, destination, probability)`` edges, indexed
+    against ``build_states(min_intron_length)``.
+
+    Weights are taken directly from the feature matrix.  Where several expanded
+    successors share a feature *and* are mutually exclusive under their base
+    constraints -- for instance ``cds_p0_t`` and ``cds_p0_x`` -- each receives
+    the full feature weight rather than a share of it, because which one applies
+    is determined by the sequence, not by chance.  :func:`validate_edges` checks
+    that this never lets the feasible weight out of a state exceed 1.
+    """
+    p = np.asarray(feature_probs, dtype=float)
+    if p.shape != (N_FEATURES, N_FEATURES):
+        raise ValueError(f"Expected a {N_FEATURES}x{N_FEATURES} matrix; got {p.shape}")
+
+    chain_parts = intron_chain_parts(min_intron_length)
+    s = {state.name: i for i, state in enumerate(build_states(min_intron_length))}
+    edges: list[tuple[int, int, float]] = []
+
+    def add(source: str, destination: str, weight: float) -> None:
+        if weight > 0:
+            edges.append((s[source], s[destination], float(weight)))
+
+    cds_cont, cds_intron, cds_end = p[CDS][CDS], p[CDS][IN], p[CDS][U3]
+    intron_stay = p[IN][IN]
+    intron_exit = 1.0 - intron_stay
+
+    # -- intergenic and 5' UTR ------------------------------------------------
+    add("intergenic", "intergenic", p[IG][IG])
+    add("intergenic", "utr5", p[IG][U5])
+
+    def enter_intron(source: str, intron_class: str, weight: float) -> None:
+        add(source, intron_state(intron_class, "d1"), weight)
+
+    add("utr5", "utr5", p[U5][U5])
+    enter_intron("utr5", "utr5", p[U5][IN])
+    add("utr5", "start_a", p[U5][CDS])
+
+    # -- start codon ----------------------------------------------------------
+    add("start_a", "start_t", 1.0)
+    add("start_t", "start_g", 1.0)
+
+    def leave_codon_boundary(source: str) -> None:
+        """Successors of a CDS base that completes a codon.
+
+        The next base either opens an intron, continues the coding sequence, or
+        begins the terminal stop codon.  Reaching the 3' UTR is only possible
+        through that stop codon, so the feature matrix's CDS -> 3' UTR mass is
+        what drives entry into it.
+        """
+        enter_intron(source, "p2", cds_intron)
+        add(source, "cds_p0_t", cds_cont)
+        add(source, "cds_p0_x", cds_cont)
+        add(source, "stop_t", cds_end)
+
+    leave_codon_boundary("start_g")
+
+    # -- CDS body -------------------------------------------------------------
+    # Mid-codon there is nowhere to go but onward or into an intron, so the
+    # CDS -> 3' UTR mass folds into continuing.
+    cds_onward = cds_cont + cds_end
+
+    enter_intron("cds_p0_t", "p0t", cds_intron)
+    add("cds_p0_t", "cds_p1_ta", cds_onward)
+    add("cds_p0_t", "cds_p1_tg", cds_onward)
+    add("cds_p0_t", "cds_p1_safe_t", cds_onward)
+
+    enter_intron("cds_p0_x", "p0x", cds_intron)
+    add("cds_p0_x", "cds_p1_safe_x", cds_onward)
+
+    enter_intron("cds_p1_ta", "p1ta", cds_intron)
+    add("cds_p1_ta", "cds_p2_ta", cds_onward)
+
+    enter_intron("cds_p1_tg", "p1tg", cds_intron)
+    add("cds_p1_tg", "cds_p2_tg", cds_onward)
+
+    for source in ("cds_p1_safe_t", "cds_p1_safe_x"):
+        enter_intron(source, "p1safe", cds_intron)
+        add(source, "cds_p2_safe", cds_onward)
+
+    for source in ("cds_p2_ta", "cds_p2_tg", "cds_p2_safe"):
+        leave_codon_boundary(source)
+
+    # -- terminal stop codon and 3' UTR --------------------------------------
+    add("stop_t", "stop_a", 1.0)
+    add("stop_t", "stop_g", 1.0)
+    add("stop_a", "stop_end_a", 1.0)
+    add("stop_g", "stop_end_g", 1.0)
+    add("stop_end_a", "utr3", 1.0)
+    add("stop_end_g", "utr3", 1.0)
+
+    add("utr3", "utr3", p[U3][U3])
+    enter_intron("utr3", "utr3", p[U3][IN])
+    add("utr3", "intergenic", p[U3][IG])
+
+    # -- intron chains --------------------------------------------------------
+    # Each intron runs G -> T/C -> b1..bk -> body* -> A -> G before resuming.
+    # The b-states are mandatory, which is what imposes the minimum intron
+    # length; the decision to end the intron is taken on leaving the looping
+    # body state, and the acceptor states that follow are forced, so the exit
+    # weight sits on that one edge.
+    resume_weights = {
+        # A 5' UTR intron may resume into more UTR or straight into the start
+        # codon, and those two are not mutually exclusive under their masks, so
+        # they share the exit mass.
+        "utr5": {"utr5": 0.5, "start_a": 0.5},
+        # At a codon boundary the intron resumes into the next codon or into the
+        # terminal stop codon, in the same ratio a coding base would.
+        "p2": {
+            "cds_p0_t": cds_cont / (cds_cont + cds_end),
+            "cds_p0_x": cds_cont / (cds_cont + cds_end),
+            "stop_t": cds_end / (cds_cont + cds_end),
+        },
+    }
+    for intron_class, destinations in INTRON_CLASSES:
+        chain = [intron_state(intron_class, part) for part, _ in chain_parts]
+        body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
+        # Donor and the mandatory body positions are a forced march
+        for source, destination in zip(chain, chain[1:-2]):
+            add(source, destination, 1.0)
+        add(body, body, intron_stay)
+        add(body, acceptor_1, intron_exit)
+        add(acceptor_1, acceptor_2, 1.0)
+        weights = resume_weights.get(intron_class, {})
+        for destination in destinations:
+            add(acceptor_2, destination, weights.get(destination, 1.0))
+
+    return edges
+
+
+def validate_edges(
+    edges: list[tuple[int, int, float]],
+    mask_table: np.ndarray,
+    states: list[State] | None = None,
+) -> None:
+    """Check that no state can emit more than unit probability at any base.
+
+    Expanded successors that share a feature weight are only legitimate because
+    their base constraints are mutually exclusive.  This asserts that property
+    directly: for every state and every possible next base, the weights of the
+    successors actually reachable at that base must not exceed 1.  It also
+    checks that the graph is fully connected, since an unreachable state would
+    silently disable whatever constraint it carries.
+    """
+    if states is None:
+        states = STATES
+
+    outgoing: dict[int, list[tuple[int, float]]] = {}
+    for source, destination, weight in edges:
+        outgoing.setdefault(source, []).append((destination, weight))
+
+    for source, successors in outgoing.items():
+        for base in range(N_BASE_CODES):
+            total = sum(
+                weight
+                for destination, weight in successors
+                if mask_table[states[destination].mask, base]
+            )
+            if total > 1.0 + 1e-9:
+                raise ValueError(
+                    f"State {states[source].name!r} has feasible outgoing probability "
+                    f"{total:.6f} > 1 for base code {base}; expanded successors that "
+                    f"share a feature weight must be mutually exclusive"
+                )
+
+    all_states = set(range(len(states)))
+    orphans = all_states - {destination for _, destination, _ in edges}
+    dead_ends = all_states - set(outgoing)
+    if orphans or dead_ends:
+        raise ValueError(
+            f"Disconnected states: no incoming {[states[i].name for i in sorted(orphans)]}, "
+            f"no outgoing {[states[i].name for i in sorted(dead_ends)]}"
+        )
+
+
+class PredecessorIndex(NamedTuple):
+    """Edges indexed by destination, plus the back-pointer layout.
+
+    Most states in the expanded graph -- every donor, mandatory-body and
+    acceptor position of every intron -- have exactly one predecessor, so the
+    path into them is not a choice and needs no back-pointer.  Recording
+    back-pointers only for the states that actually branch keeps the table
+    narrow no matter how long the intron chains get, which is what makes a
+    realistic minimum intron length affordable: the state count grows but the
+    per-position memory does not.
+    """
+
+    indptr: np.ndarray
+    sources: np.ndarray
+    log_weights: np.ndarray
+    sole_predecessor: np.ndarray  # -1 where the state branches
+    branch_column: np.ndarray  # -1 where the state does not branch
+    n_branch_columns: int
+
+
+def build_predecessor_csr(
+    edges: list[tuple[int, int, float]], n_states: int = -1
+) -> PredecessorIndex:
+    if n_states < 0:
+        n_states = N_STATES
+    by_destination: dict[int, list[tuple[int, float]]] = {
+        j: [] for j in range(n_states)
+    }
+    for source, destination, weight in edges:
+        by_destination[destination].append((source, weight))
+
+    indptr = np.zeros(n_states + 1, dtype=np.int64)
+    sources: list[int] = []
+    log_weights: list[float] = []
+    sole_predecessor = np.full(n_states, -1, dtype=np.int16)
+    branch_column = np.full(n_states, -1, dtype=np.int16)
+    n_branch_columns = 0
+
+    for destination in range(n_states):
+        predecessors = sorted(by_destination[destination])
+        for source, weight in predecessors:
+            sources.append(source)
+            log_weights.append(np.log(weight))
+        indptr[destination + 1] = len(sources)
+        if len(predecessors) == 1:
+            sole_predecessor[destination] = predecessors[0][0]
+        elif len(predecessors) > 1:
+            branch_column[destination] = n_branch_columns
+            n_branch_columns += 1
+
+    return PredecessorIndex(
+        indptr,
+        np.asarray(sources, dtype=np.int64),
+        np.asarray(log_weights, dtype=np.float64),
+        sole_predecessor,
+        branch_column,
+        n_branch_columns,
+    )
+
+
+_BASE_LOOKUP = np.full(256, BASE_OTHER, dtype=np.uint8)
+for _char, _code in (("A", BASE_A), ("C", BASE_C), ("G", BASE_G), ("T", BASE_T)):
+    _BASE_LOOKUP[ord(_char)] = _code
+    _BASE_LOOKUP[ord(_char.lower())] = _code
+
+_COMPLEMENT_CODE = np.array(
+    [BASE_T, BASE_G, BASE_C, BASE_A, BASE_OTHER], dtype=np.uint8
+)
+
+
+def encode_sequence(sequence: str) -> np.ndarray:
+    """Encode a nucleotide string as base codes, case-insensitively."""
+    raw = np.frombuffer(sequence.encode("ascii", "replace"), dtype=np.uint8)
+    return _BASE_LOOKUP[raw]
+
+
+def reverse_complement_codes(codes: np.ndarray) -> np.ndarray:
+    """Reverse complement an encoded sequence.
+
+    Predictions for the minus strand are decoded on the reversed logit array, so
+    the base at reversed index ``i`` is the complement of the base at genomic
+    index ``len - 1 - i``.  The result is materialised contiguously rather than
+    left as a reverse-strided view, which the decoding kernel reads far faster.
+    """
+    return np.ascontiguousarray(_COMPLEMENT_CODE[codes][::-1])
+
+
+@njit(cache=True)
+def _masked_viterbi(
+    log_emission: np.ndarray,
+    base_codes: np.ndarray,
+    state_feature: np.ndarray,
+    state_mask: np.ndarray,
+    mask_table: np.ndarray,
+    pred_indptr: np.ndarray,
+    pred_sources: np.ndarray,
+    pred_log_weights: np.ndarray,
+    sole_predecessor: np.ndarray,
+    branch_column: np.ndarray,
+    n_branch_columns: int,
+    log_initial: np.ndarray,
+) -> np.ndarray:
+    """Viterbi over a sparse, per-position-masked state graph.
+
+    Only the previous score row is retained, and back-pointers are stored only
+    for states that have more than one predecessor, so per-position memory is
+    two bytes per branching state regardless of how many forced chain states the
+    graph contains.
+    """
+    n_positions = log_emission.shape[0]
+    n_states = state_feature.shape[0]
+
+    scores = np.full((2, n_states), NEG_INF)
+    backpointer = np.full((n_positions, n_branch_columns), -1, dtype=np.int16)
+
+    base = base_codes[0]
+    for j in range(n_states):
+        if mask_table[state_mask[j], base]:
+            scores[0, j] = log_initial[j] + log_emission[0, state_feature[j]]
+
+    for t in range(1, n_positions):
+        previous = (t - 1) % 2
+        current = t % 2
+        base = base_codes[t]
+        for j in range(n_states):
+            if not mask_table[state_mask[j], base]:
+                scores[current, j] = NEG_INF
+                continue
+            best = NEG_INF
+            best_source = -1
+            for k in range(pred_indptr[j], pred_indptr[j + 1]):
+                i = pred_sources[k]
+                value = scores[previous, i] + pred_log_weights[k]
+                if value > best:
+                    best = value
+                    best_source = i
+            if best_source < 0:
+                scores[current, j] = NEG_INF
+            else:
+                scores[current, j] = best + log_emission[t, state_feature[j]]
+                column = branch_column[j]
+                if column >= 0:
+                    backpointer[t, column] = best_source
+
+    last = (n_positions - 1) % 2
+    best_state = 0
+    best_score = scores[last, 0]
+    for j in range(1, n_states):
+        if scores[last, j] > best_score:
+            best_score = scores[last, j]
+            best_state = j
+
+    path = np.empty(n_positions, dtype=np.int16)
+    path[n_positions - 1] = best_state
+    for t in range(n_positions - 1, 0, -1):
+        column = branch_column[best_state]
+        if column < 0:
+            source = sole_predecessor[best_state]
+        else:
+            source = backpointer[t, column]
+        if source < 0:
+            # Defensive: a severed path can only arise from a fully masked
+            # column, which cannot happen while the intergenic state is
+            # unconstrained.  Fall back to intergenic rather than crash.
+            source = 0
+        best_state = source
+        path[t - 1] = best_state
+
+    return path
+
+
+def frame_aware_decode(
+    feature_probs: npt.ArrayLike,
+    base_codes: np.ndarray,
+    feature_transition: npt.ArrayLike,
+    epsilon: float | None = None,
+    return_states: bool = False,
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+) -> np.ndarray:
+    """Decode per-base feature probabilities under frame and codon constraints.
+
+    Parameters
+    ----------
+    feature_probs
+        Array of shape ``(T, 5)`` of per-base feature probabilities, ordered as
+        ``[intergenic, intron, five_prime_utr, cds, three_prime_utr]``.
+    base_codes
+        Array of shape ``(T,)`` from :func:`encode_sequence`, in the same
+        orientation as ``feature_probs``.
+    feature_transition
+        The ``5x5`` feature transition matrix, already regularized if desired.
+        Regularization must be applied here rather than to the expanded matrix:
+        smoothing the expanded transitions would destroy the structural zeros
+        that enforce the reading frame.
+    epsilon
+        Floor added to probabilities before taking logs.
+    return_states
+        Return expanded state indices instead of feature labels.  Intended for
+        tests and diagnostics.  Indices refer to
+        ``build_states(min_intron_length)``.
+    min_intron_length
+        Shortest intron the decoder may emit.  Introns below this length are
+        overwhelmingly artefacts of stepping over an in-frame stop codon rather
+        than real splicing.
+
+    Returns
+    -------
+    np.ndarray
+        Feature labels of shape ``(T,)`` with values in ``0..4``, or expanded
+        state indices when ``return_states`` is set.
+    """
+    feature_probs = np.asarray(feature_probs)
+    if feature_probs.ndim != 2 or feature_probs.shape[1] != N_FEATURES:
+        raise ValueError(
+            f"Expected feature probs of shape (T, 5); got {feature_probs.shape}"
+        )
+    base_codes = np.ascontiguousarray(base_codes, dtype=np.uint8)
+    if base_codes.shape[0] != feature_probs.shape[0]:
+        raise ValueError(
+            f"Sequence length {base_codes.shape[0]} does not match the number of "
+            f"predicted positions {feature_probs.shape[0]}"
+        )
+    if epsilon is None:
+        epsilon = float(np.finfo(np.float32).tiny)
+
+    states = build_states(min_intron_length)
+    n_states = len(states)
+    mask_table = build_mask_table()
+    edges = build_edges(np.asarray(feature_transition, dtype=float), min_intron_length)
+    validate_edges(edges, mask_table, states)
+    index = build_predecessor_csr(edges, n_states)
+
+    state_feature = np.array([state.feature for state in states], dtype=np.int64)
+    state_mask = np.array([state.mask for state in states], dtype=np.int64)
+
+    # The initial distribution is deliberately weak: chromosomes begin in
+    # intergenic sequence, and over millions of positions the choice is
+    # immaterial to the decoded path.
+    initial = np.full(n_states, 1.0 / (10 * n_states))
+    initial[[state.name for state in states].index("intergenic")] = 1.0
+    log_initial = np.log(initial / initial.sum())
+
+    # Build the log-emission array with a single allocation.  At one row per
+    # base this is gigabytes for a large chromosome, so the naive
+    # `np.log(probs + eps)` -- which materialises two more full-size temporaries
+    # -- is worth avoiding.
+    log_emission = np.array(feature_probs, dtype=np.float32, copy=True)
+    np.add(log_emission, np.float32(epsilon), out=log_emission)
+    np.log(log_emission, out=log_emission)
+
+    logger.info(
+        f"Frame-aware decoding of {log_emission.shape[0]} positions over "
+        f"{n_states} states ({len(edges)} transitions, "
+        f"{index.n_branch_columns} with back-pointers, "
+        f"min_intron_length={min_intron_length})"
+    )
+    path = _masked_viterbi(
+        log_emission,
+        base_codes,
+        state_feature,
+        state_mask,
+        mask_table,
+        index.indptr,
+        index.sources,
+        index.log_weights,
+        index.sole_predecessor,
+        index.branch_column,
+        index.n_branch_columns,
+        log_initial,
+    )
+    if return_states:
+        return path.astype(np.int64)
+    return state_feature[path.astype(np.int64)]

--- a/src/frame_hmm.py
+++ b/src/frame_hmm.py
@@ -331,6 +331,7 @@ def build_edges(
             edges.append((s[source], s[destination], float(weight)))
 
     cds_cont, cds_intron, cds_end = p[CDS][CDS], p[CDS][IN], p[CDS][U3]
+    utr5_cont, utr5_intron, utr5_end = p[U5][U5], p[U5][IN], p[U5][CDS]
     intron_stay = p[IN][IN]
     intron_exit = 1.0 - intron_stay
 
@@ -346,9 +347,9 @@ def build_edges(
         for group in splice_motif_groups:
             add(source, intron_state(intron_class, group.name, "d1"), weight)
 
-    add("utr5", "utr5", p[U5][U5])
-    enter_intron("utr5", "utr5", p[U5][IN])
-    add("utr5", "start_a", p[U5][CDS])
+    add("utr5", "utr5", utr5_cont)
+    enter_intron("utr5", "utr5", utr5_intron)
+    add("utr5", "start_a", utr5_end)
 
     # -- start codon ----------------------------------------------------------
     add("start_a", "start_t", 1.0)
@@ -416,9 +417,13 @@ def build_edges(
     # the exit weight sits on that one edge.
     resume_weights = {
         # A 5' UTR intron may resume into more UTR or straight into the start
-        # codon, and those two are not mutually exclusive under their masks, so
-        # they share the exit mass.
-        "utr5": {"utr5": 0.5, "start_a": 0.5},
+        # codon; those two are not mutually exclusive under their masks, so
+        # they share the exit mass in the same ratio a UTR base would transition,
+        # rather than splitting it arbitrarily.
+        "utr5": {
+            "utr5": utr5_cont / (utr5_cont + utr5_end),
+            "start_a": utr5_end / (utr5_cont + utr5_end),
+        },
         # At a codon boundary the intron resumes into the next codon or into the
         # terminal stop codon, in the same ratio a coding base would.
         "p2": {

--- a/src/frame_hmm.py
+++ b/src/frame_hmm.py
@@ -35,7 +35,8 @@ this occurs in real genes but is rare, and supporting it would roughly double th
 state count.
 
 Introns additionally carry their donor and acceptor dinucleotides as states, so
-every emitted intron is canonical (GT-AG or GC-AG).  That constraint is load
+every emitted intron matches one of the configured splice motifs (GT-AG and
+GC-AG by default; see :class:`SpliceMotifGroup`).  That constraint is load
 bearing rather than decorative: given only the frame constraints, the cheapest
 way for the decoder to escape an in-frame stop codon is to invent a two-base
 intron across it, and measured on real predictions it did so readily.
@@ -54,7 +55,16 @@ predecessor each, so they cost states but no back-pointer memory (see
 
 Known limitations
 -----------------
-* U12-type AT-AC introns (~0.1-0.3% of introns) cannot be represented.
+* U12-type AT-AC introns are off by default. They are real but rare (~0.04%
+  of introns in the TAIR12 reference, against >99.9% GT-AG/GC-AG), and
+  supporting them roughly doubles the intron state count -- each configured
+  :class:`SpliceMotifGroup` gets its own donor, body and acceptor sub-chain,
+  since a donor from one group must never resume through another group's
+  acceptor. Pass ``splice_motif_groups=(GT_AG, AT_AC)`` to
+  :func:`build_states`/:func:`build_edges`/:func:`frame_aware_decode` to
+  enable them. Motifs beyond GT-AG, GC-AG and AT-AC are not offered: every
+  other dinucleotide pairing combined accounts for under 0.02% of introns in
+  that reference, consistent with annotation noise rather than real splicing.
 * Introns are not permitted to interrupt the start or the stop codon.
 * Genes must have both a 5' and a 3' UTR, as in the unconstrained decoder.
 """
@@ -89,7 +99,8 @@ MASK_NOT_A = 5
 MASK_NOT_AG = 6
 MASK_IS_AG = 7
 MASK_IS_TC = 8
-N_MASKS = 9
+MASK_IS_C = 9
+N_MASKS = 10
 
 # A large finite stand-in for -inf, so that adding two of them cannot produce NaN
 NEG_INF = -1e30
@@ -118,6 +129,7 @@ def build_mask_table() -> np.ndarray:
     table[MASK_IS_AG, BASE_G] = True
     table[MASK_IS_TC, BASE_T] = True
     table[MASK_IS_TC, BASE_C] = True
+    table[MASK_IS_C, BASE_C] = True
     return table
 
 
@@ -178,22 +190,69 @@ INTRON_CLASSES: list[tuple[str, tuple[str, ...]]] = [
     ("utr3", ("utr3",)),
 ]
 
+
+@dataclass(frozen=True)
+class SpliceMotifGroup:
+    """Donor dinucleotides that share a single acceptor dinucleotide.
+
+    Pairing, not the donor alone, is what a spliceosome enforces: the major
+    (U2) spliceosome accepts either GT or GC at the 5' splice site but always
+    requires AG at the 3', while the minor (U12) spliceosome is strict and
+    requires AT...AC.  Grouping by shared acceptor is what lets GT and GC
+    share one acceptor sub-chain while AT gets its own -- a donor from one
+    group can never resume through another group's acceptor.
+    """
+
+    name: str
+    donor_masks: tuple[int, int]
+    acceptor_masks: tuple[int, int]
+
+
+GT_AG = SpliceMotifGroup("gtag", (MASK_IS_G, MASK_IS_TC), (MASK_IS_A, MASK_IS_G))
+AT_AC = SpliceMotifGroup("atac", (MASK_IS_A, MASK_IS_T), (MASK_IS_A, MASK_IS_C))
+
+# GT-AG and GC-AG account for >99.9% of introns in the TAIR12 reference (chr5:
+# 45,058 GT-AG + 484 GC-AG of 45,597 total). AT-AC (U12-type) is real but rare
+# there (20 introns, 0.044%) and every other dinucleotide pairing combined
+# accounts for under 0.02% -- almost certainly annotation noise rather than
+# alternative splicing -- so only AT-AC is offered as an opt-in extra. Adding
+# a group roughly doubles the intron state count (each gets its own donor,
+# body and acceptor sub-chain, see `intron_chain_parts`), so it is off by
+# default; pass ``splice_motif_groups=(GT_AG, AT_AC)`` to enable it.
+DEFAULT_SPLICE_MOTIF_GROUPS: tuple[SpliceMotifGroup, ...] = (GT_AG,)
+
 # The donor and acceptor account for four bases; a minimum-length intron also
 # needs at least one body base, so this is the shortest intron representable.
 STRUCTURAL_MIN_INTRON_LENGTH = 5
 
-# In the TAIR12 chr4 reference only 0.07% of introns are shorter than 20 nt,
-# while an unconstrained frame-aware decoder emits ~0.4% -- the excess being
-# short introns invented to step over an in-frame stop codon.  Twenty is short
-# enough to keep essentially every real intron and long enough to close that gap.
+# Twenty is deliberately below the ~40-70 nt often quoted as a minimum for
+# spliceosomal lariat formation. Checked across 64 Phytozome angiosperm
+# reference annotations (~14.5M introns total, not just Arabidopsis): only
+# 0.13% of introns are shorter than 20 nt, but raising the floor to 40 would
+# exclude 0.43% more -- and 37 of the 64 species have at least one genuine
+# sub-20nt intron, with a handful (e.g. Lens ervoides, Brassica oleracea,
+# Arachis hypogaea) north of 1%. Meanwhile an unconstrained frame-aware
+# decoder emits ~0.4% of introns below 20 nt on Arabidopsis -- the excess
+# being short introns invented to step over an in-frame stop codon. Twenty
+# keeps essentially every real intron across these genomes while still
+# closing that gap. This is only a default: pass a larger value (e.g. via
+# --min-intron-length in scripts/detect_intervals.py) to enforce a stricter,
+# more textbook-canonical minimum for organisms where that's preferred.
 DEFAULT_MIN_INTRON_LENGTH = 20
 
 
-def intron_chain_parts(min_intron_length: int) -> list[tuple[str, int]]:
-    """(suffix, base constraint) for the states of one intron chain.
+def intron_chain_parts(
+    min_intron_length: int,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
+) -> dict[str, list[tuple[str, int]]]:
+    """Per-group (suffix, base constraint) lists for the states of one intron.
 
-    ``b1..bk`` are mandatory body positions that impose the minimum length; the
-    looping ``body`` state that follows is what actually absorbs intron length.
+    Keyed by :attr:`SpliceMotifGroup.name`. Within a group's chain, ``b1..bk``
+    are mandatory body positions that impose the minimum length; the looping
+    ``body`` state that follows is what actually absorbs intron length. Groups
+    never merge -- each gets its own donor, body and acceptor states -- so an
+    intron entered through one group's donor can only leave through that same
+    group's acceptor.
     """
     if min_intron_length < STRUCTURAL_MIN_INTRON_LENGTH:
         raise ValueError(
@@ -201,23 +260,35 @@ def intron_chain_parts(min_intron_length: int) -> list[tuple[str, int]]:
             f"got {min_intron_length}"
         )
     mandatory = min_intron_length - STRUCTURAL_MIN_INTRON_LENGTH
-    return (
-        [("d1", MASK_IS_G), ("d2", MASK_IS_TC)]  # donor: GT or GC
-        + [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)]
-        + [("body", MASK_ANY)]
-        + [("a1", MASK_IS_A), ("a2", MASK_IS_G)]  # acceptor: AG
-    )
+    body_parts = [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)] + [
+        ("body", MASK_ANY)
+    ]
+    return {
+        group.name: (
+            [("d1", group.donor_masks[0]), ("d2", group.donor_masks[1])]
+            + body_parts
+            + [("a1", group.acceptor_masks[0]), ("a2", group.acceptor_masks[1])]
+        )
+        for group in splice_motif_groups
+    }
 
 
-def intron_state(intron_class: str, part: str) -> str:
-    return f"intron_{intron_class}_{part}"
+def intron_state(intron_class: str, group_name: str, part: str) -> str:
+    return f"intron_{intron_class}_{group_name}_{part}"
 
 
-def build_states(min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH) -> list[State]:
+def build_states(
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
+) -> list[State]:
     states = list(CORE_STATES)
+    chain_parts = intron_chain_parts(min_intron_length, splice_motif_groups)
     for intron_class, _ in INTRON_CLASSES:
-        for part, mask in intron_chain_parts(min_intron_length):
-            states.append(State(intron_state(intron_class, part), IN, mask))
+        for group_name, parts in chain_parts.items():
+            for part, mask in parts:
+                states.append(
+                    State(intron_state(intron_class, group_name, part), IN, mask)
+                )
     return states
 
 
@@ -230,6 +301,7 @@ N_STATES = len(STATES)
 def build_edges(
     feature_probs: np.ndarray,
     min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
 ) -> list[tuple[int, int, float]]:
     """Expand the 5x5 feature transition matrix into the frame-aware state graph.
 
@@ -247,8 +319,11 @@ def build_edges(
     if p.shape != (N_FEATURES, N_FEATURES):
         raise ValueError(f"Expected a {N_FEATURES}x{N_FEATURES} matrix; got {p.shape}")
 
-    chain_parts = intron_chain_parts(min_intron_length)
-    s = {state.name: i for i, state in enumerate(build_states(min_intron_length))}
+    chain_parts = intron_chain_parts(min_intron_length, splice_motif_groups)
+    s = {
+        state.name: i
+        for i, state in enumerate(build_states(min_intron_length, splice_motif_groups))
+    }
     edges: list[tuple[int, int, float]] = []
 
     def add(source: str, destination: str, weight: float) -> None:
@@ -264,7 +339,12 @@ def build_edges(
     add("intergenic", "utr5", p[IG][U5])
 
     def enter_intron(source: str, intron_class: str, weight: float) -> None:
-        add(source, intron_state(intron_class, "d1"), weight)
+        # Each configured motif group's donor mask is mutually exclusive with
+        # every other group's (G-first vs A-first), so -- as with cds_p0_t /
+        # cds_p0_x above -- each gets the full weight rather than a share of
+        # it; only one can ever be feasible for a given base.
+        for group in splice_motif_groups:
+            add(source, intron_state(intron_class, group.name, "d1"), weight)
 
     add("utr5", "utr5", p[U5][U5])
     enter_intron("utr5", "utr5", p[U5][IN])
@@ -328,11 +408,12 @@ def build_edges(
     add("utr3", "intergenic", p[U3][IG])
 
     # -- intron chains --------------------------------------------------------
-    # Each intron runs G -> T/C -> b1..bk -> body* -> A -> G before resuming.
-    # The b-states are mandatory, which is what imposes the minimum intron
-    # length; the decision to end the intron is taken on leaving the looping
-    # body state, and the acceptor states that follow are forced, so the exit
-    # weight sits on that one edge.
+    # Each intron runs donor -> b1..bk -> body* -> acceptor before resuming,
+    # separately per configured motif group (e.g. G -> T/C -> ... -> A -> G for
+    # GT_AG). The b-states are mandatory, which is what imposes the minimum
+    # intron length; the decision to end the intron is taken on leaving the
+    # looping body state, and the acceptor states that follow are forced, so
+    # the exit weight sits on that one edge.
     resume_weights = {
         # A 5' UTR intron may resume into more UTR or straight into the start
         # codon, and those two are not mutually exclusive under their masks, so
@@ -347,17 +428,18 @@ def build_edges(
         },
     }
     for intron_class, destinations in INTRON_CLASSES:
-        chain = [intron_state(intron_class, part) for part, _ in chain_parts]
-        body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
-        # Donor and the mandatory body positions are a forced march
-        for source, destination in zip(chain, chain[1:-2]):
-            add(source, destination, 1.0)
-        add(body, body, intron_stay)
-        add(body, acceptor_1, intron_exit)
-        add(acceptor_1, acceptor_2, 1.0)
-        weights = resume_weights.get(intron_class, {})
-        for destination in destinations:
-            add(acceptor_2, destination, weights.get(destination, 1.0))
+        for group_name, parts in chain_parts.items():
+            chain = [intron_state(intron_class, group_name, part) for part, _ in parts]
+            body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
+            # Donor and the mandatory body positions are a forced march
+            for source, destination in zip(chain, chain[1:-2]):
+                add(source, destination, 1.0)
+            add(body, body, intron_stay)
+            add(body, acceptor_1, intron_exit)
+            add(acceptor_1, acceptor_2, 1.0)
+            weights = resume_weights.get(intron_class, {})
+            for destination in destinations:
+                add(acceptor_2, destination, weights.get(destination, 1.0))
 
     return edges
 
@@ -585,6 +667,7 @@ def frame_aware_decode(
     epsilon: float | None = None,
     return_states: bool = False,
     min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
 ) -> np.ndarray:
     """Decode per-base feature probabilities under frame and codon constraints.
 
@@ -611,6 +694,10 @@ def frame_aware_decode(
         Shortest intron the decoder may emit.  Introns below this length are
         overwhelmingly artefacts of stepping over an in-frame stop codon rather
         than real splicing.
+    splice_motif_groups
+        Which donor/acceptor dinucleotide pairings an intron may use. Defaults
+        to GT-AG/GC-AG only; pass ``(GT_AG, AT_AC)`` to also allow U12-type
+        AT-AC introns, at the cost of roughly doubling the intron state count.
 
     Returns
     -------
@@ -632,10 +719,14 @@ def frame_aware_decode(
     if epsilon is None:
         epsilon = float(np.finfo(np.float32).tiny)
 
-    states = build_states(min_intron_length)
+    states = build_states(min_intron_length, splice_motif_groups)
     n_states = len(states)
     mask_table = build_mask_table()
-    edges = build_edges(np.asarray(feature_transition, dtype=float), min_intron_length)
+    edges = build_edges(
+        np.asarray(feature_transition, dtype=float),
+        min_intron_length,
+        splice_motif_groups,
+    )
     validate_edges(edges, mask_table, states)
     index = build_predecessor_csr(edges, n_states)
 
@@ -661,7 +752,8 @@ def frame_aware_decode(
         f"Frame-aware decoding of {log_emission.shape[0]} positions over "
         f"{n_states} states ({len(edges)} transitions, "
         f"{index.n_branch_columns} with back-pointers, "
-        f"min_intron_length={min_intron_length})"
+        f"min_intron_length={min_intron_length}, "
+        f"splice_motif_groups={[g.name for g in splice_motif_groups]})"
     )
     path = _masked_viterbi(
         log_emission,

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -1,0 +1,325 @@
+"""Tests for the ORF-aware CDS boundary repair step (``scripts/fix_orf.py``)."""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+# scripts/ is not an importable package, so load the module by path.  It must be
+# registered in sys.modules before execution, otherwise @dataclass cannot
+# resolve the module namespace while processing the class bodies.
+_MODULE_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "fix_orf.py"
+_spec = importlib.util.spec_from_file_location("fix_orf", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+fix_orf = importlib.util.module_from_spec(_spec)
+sys.modules["fix_orf"] = fix_orf
+_spec.loader.exec_module(fix_orf)
+
+
+# -------------------------------------------------------------------------------------------------
+# Synthetic locus
+# -------------------------------------------------------------------------------------------------
+#
+# A two-exon transcript with a known, unique ORF.  The spliced mRNA is 120 nt:
+#
+#     t[0, 10)    5' UTR    (contains no ATG, so the ORF start is unambiguous)
+#     t[10, 100)  CDS       ATG + 28 x GCT + TAA  =  90 nt, 29 residues
+#     t[100, 120) 3' UTR
+#
+# Exon 1 covers t[0, 60) and exon 2 covers t[60, 120), separated by a 60 nt
+# intron.  Splitting the CDS 50 / 40 across the two exons makes the second CDS
+# feature's GFF3 phase non-zero, which exercises the phase computation.
+
+FIVE_PRIME_UTR_SEQ = "CAAACCCGGG"  # 10 nt, no ATG
+ORF_SEQ = "ATG" + "GCT" * 28 + "TAA"  # 90 nt
+THREE_PRIME_UTR_SEQ = "CCCAAACCCAAACCCAAACC"  # 20 nt, no ATG
+MRNA_SEQ = FIVE_PRIME_UTR_SEQ + ORF_SEQ + THREE_PRIME_UTR_SEQ
+
+CANONICAL_INTRON = "GT" + "T" * 56 + "AG"
+NONCANONICAL_INTRON = "AA" + "T" * 56 + "CC"
+
+FLANK = "T" * 100
+
+# Genomic layout: FLANK | exon1 (101-160) | intron (161-220) | exon2 (221-280) | FLANK
+EXON1 = (101, 160)
+EXON2 = (221, 280)
+
+# Feature blocks of the correct annotation, as (start, end, type, phase).
+PLUS_CORRECT = [
+    (101, 110, "five_prime_UTR", "."),
+    (111, 160, "CDS", "0"),
+    (221, 260, "CDS", "1"),
+    (261, 280, "three_prime_UTR", "."),
+]
+MINUS_CORRECT = [
+    (101, 120, "three_prime_UTR", "."),
+    (121, 160, "CDS", "1"),
+    (221, 270, "CDS", "0"),
+    (271, 280, "five_prime_UTR", "."),
+]
+
+# The same locus with the CDS wrongly extended over the entire transcript, so
+# it neither starts on ATG nor ends on a stop codon.
+PLUS_BROKEN = [(101, 160, "CDS", "0"), (221, 280, "CDS", "0")]
+MINUS_BROKEN = [(101, 160, "CDS", "0"), (221, 280, "CDS", "0")]
+
+
+def build_chromosome(strand: str, intron: str = CANONICAL_INTRON) -> str:
+    locus = MRNA_SEQ[:60] + intron + MRNA_SEQ[60:]
+    assert len(locus) == 180
+    if strand == "-":
+        locus = fix_orf.revcomp(locus)
+    return FLANK + locus + FLANK
+
+
+def build_gff(blocks, strand: str) -> str:
+    lines = [
+        "##gff-version 3",
+        f"chr1\ttest\tgene\t101\t280\t.\t{strand}\t.\tID=g1",
+        f"chr1\ttest\tmRNA\t101\t280\t.\t{strand}\t.\tID=g1.t1;Parent=g1",
+    ]
+    for start, end, feature_type, phase in blocks:
+        lines.append(
+            f"chr1\ttest\t{feature_type}\t{start}\t{end}\t.\t{strand}\t{phase}\t"
+            f"Parent=g1.t1"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run(tmp_path, blocks, strand, intron=CANONICAL_INTRON, **kwargs):
+    """Run fix_orf over a synthetic locus and return (stats, parsed records)."""
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(build_gff(blocks, strand))
+    fasta.write_text(">chr1\n" + build_chromosome(strand, intron) + "\n")
+
+    options: dict[str, object] = {
+        "max_shift": 300,
+        "min_protein_length": 10,
+        "require_canonical": True,
+        "report_path": None,
+    }
+    options.update(kwargs)
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        **options,  # pyrefly: ignore[bad-argument-type]
+    )
+    _, records = fix_orf.read_gff(str(out))
+    return stats, records
+
+
+def exonic(records):
+    return sorted(
+        (r.start, r.end, r.type, r.phase)
+        for r in records
+        if r.type in fix_orf.EXONIC_TYPES
+    )
+
+
+def mrna_attributes(records):
+    return next(r.attributes for r in records if r.type == "mRNA")
+
+
+# -------------------------------------------------------------------------------------------------
+# Tests
+# -------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strand,correct", [("+", PLUS_CORRECT), ("-", MINUS_CORRECT)])
+def test_valid_orf_is_recognised_and_left_alone(tmp_path, strand, correct):
+    """A transcript that already encodes a complete ORF must not be modified."""
+    stats, records = run(tmp_path, correct, strand)
+
+    assert stats["complete"] == 1
+    assert stats["repaired"] == 0
+    assert exonic(records) == sorted(correct)
+    assert mrna_attributes(records)["orf_status"] == "complete"
+    assert "partial" not in mrna_attributes(records)
+
+
+@pytest.mark.parametrize(
+    "strand,broken,correct",
+    [("+", PLUS_BROKEN, PLUS_CORRECT), ("-", MINUS_BROKEN, MINUS_CORRECT)],
+)
+def test_broken_cds_is_repaired_to_the_true_orf(tmp_path, strand, broken, correct):
+    """Moving only the TIS and TTS within the transcript recovers the real ORF,
+    and the recovered CDS carries correct GFF3 phases."""
+    stats, records = run(tmp_path, broken, strand)
+
+    assert stats["repaired"] == 1
+    assert exonic(records) == sorted(correct)
+
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "repaired"
+    assert attributes["orf_shift_5"] == "10"  # CDS start moved 10 nt downstream
+    assert attributes["orf_shift_3"] == "-20"  # CDS end moved 20 nt upstream
+
+
+def test_minus_strand_splicing_preserves_exon_order(tmp_path):
+    """Regression: the spliced sequence must be assembled in ascending genomic
+    order before reverse complementing.  Reverse complementing exons that are
+    already in coding order silently reverses them, which yields a scrambled
+    transcript and bogus 'repairs'."""
+    _, records = run(tmp_path, MINUS_CORRECT, "-")
+    transcript = fix_orf.Transcript(
+        mrna=next(r for r in records if r.type == "mRNA"),
+        children=[r for r in records if r.type in fix_orf.EXONIC_TYPES],
+        seqid="chr1",
+        strand="-",
+    )
+    transcript.build_exons()
+    assert transcript.spliced_sequence(build_chromosome("-")) == MRNA_SEQ
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+def test_exon_structure_and_transcript_span_are_never_changed(tmp_path, strand):
+    """A repair may only relabel exonic sequence: exon blocks, and therefore
+    every splice junction, must survive untouched."""
+    broken = PLUS_BROKEN if strand == "+" else MINUS_BROKEN
+    _, records = run(tmp_path, broken, strand)
+
+    def exon_blocks(blocks):
+        merged: list[list[int]] = []
+        for start, end in sorted((b[0], b[1]) for b in blocks):
+            if merged and start <= merged[-1][1] + 1:
+                merged[-1][1] = max(merged[-1][1], end)
+            else:
+                merged.append([start, end])
+        return [tuple(b) for b in merged]
+
+    assert exon_blocks(exonic(records)) == [EXON1, EXON2]
+    mrna = next(r for r in records if r.type == "mRNA")
+    assert (mrna.start, mrna.end) == (101, 280)
+    gene = next(r for r in records if r.type == "gene")
+    assert (gene.start, gene.end) == (101, 280)
+
+
+def test_noncanonical_introns_block_repair_by_default(tmp_path):
+    """If the model's own splice calls are not canonical, no ORF is built on
+    top of them; the transcript is flagged instead."""
+    stats, records = run(tmp_path, PLUS_BROKEN, "+", intron=NONCANONICAL_INTRON)
+
+    assert stats["repaired"] == 0
+    assert stats["partial"] == 1
+    assert exonic(records) == sorted(PLUS_BROKEN)
+
+    attributes = mrna_attributes(records)
+    assert attributes["orf_issue"] == "noncanonical_intron"
+    assert attributes["partial"] == "true"
+    assert attributes["start_range"] == ".,101"
+    assert attributes["end_range"] == "280,."
+    gene = next(r for r in records if r.type == "gene")
+    assert gene.attributes["partial"] == "true"
+
+
+def test_noncanonical_introns_can_be_opted_into(tmp_path):
+    stats, records = run(
+        tmp_path, PLUS_BROKEN, "+", intron=NONCANONICAL_INTRON, require_canonical=False
+    )
+
+    assert stats["repaired"] == 1
+    assert exonic(records) == sorted(PLUS_CORRECT)
+
+
+def test_max_shift_bounds_how_far_a_boundary_may_move(tmp_path):
+    """The true ORF needs a 20 nt move at the 3' end, so a 5 nt cap must reject
+    it rather than settle for some other ORF."""
+    stats, records = run(tmp_path, PLUS_BROKEN, "+", max_shift=5)
+
+    assert stats["repaired"] == 0
+    assert stats["partial"] == 1
+    assert exonic(records) == sorted(PLUS_BROKEN)
+    assert mrna_attributes(records)["orf_issue"] == "orf_outside_window"
+
+
+def test_transcript_with_no_possible_orf_is_reported_separately(tmp_path):
+    """A transcript whose sequence contains no ATG at all is distinguished from
+    one whose ORF merely lies outside the search window."""
+    blocks = [(101, 160, "CDS", "0"), (221, 280, "CDS", "0")]
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(build_gff(blocks, "+"))
+    # Exonic sequence with no ATG anywhere, intron left canonical
+    locus = ("CCC" * 20) + CANONICAL_INTRON + ("CCC" * 20)
+    fasta.write_text(">chr1\n" + FLANK + locus + FLANK + "\n")
+
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        max_shift=300,
+        min_protein_length=10,
+        require_canonical=True,
+        report_path=None,
+    )
+
+    assert stats["partial"] == 1
+    assert stats["issue:no_orf_in_transcript"] == 1
+
+
+def test_ambiguous_bases_are_not_repaired(tmp_path):
+    """An ORF cannot be verified across an assembly gap, so N-containing
+    transcripts are flagged rather than guessed at."""
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(build_gff(PLUS_BROKEN, "+"))
+    chromosome = build_chromosome("+")
+    # Introduce an N inside exon 2, away from the CDS boundaries
+    chromosome = chromosome[:250] + "N" + chromosome[251:]
+    fasta.write_text(">chr1\n" + chromosome + "\n")
+
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        max_shift=300,
+        min_protein_length=10,
+        require_canonical=True,
+        report_path=None,
+    )
+
+    assert stats["repaired"] == 0
+    assert stats["issue:ambiguous_bases"] == 1
+
+
+def test_sequences_absent_from_the_fasta_are_passed_through(tmp_path):
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(build_gff(PLUS_BROKEN, "+"))
+    fasta.write_text(">other_contig\n" + "A" * 100 + "\n")
+
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        max_shift=300,
+        min_protein_length=10,
+        require_canonical=True,
+        report_path=None,
+    )
+
+    assert stats["skipped"] == 1
+    _, records = fix_orf.read_gff(str(out))
+    assert exonic(records) == sorted(PLUS_BROKEN)
+    # An untouched transcript must not be labelled partial: we simply don't know
+    assert "partial" not in mrna_attributes(records)
+
+
+def test_first_in_frame_stop_terminates_the_orf():
+    """A repaired ORF must stop at the first in-frame stop codon, never read
+    through one."""
+    seq = "AAA" + "ATG" + "GCT" * 5 + "TAA" + "GCT" * 5 + "TAG"
+    next_stop = fix_orf.build_next_in_frame_stop(seq)
+    assert next_stop[3] == 3 + 3 + 15  # the first TAA, not the trailing TAG
+
+    orf = fix_orf.find_best_orf(
+        seq, cds_begin=3, cds_stop=len(seq), max_shift=300, min_protein_length=1
+    )
+    assert orf == (3, 3 + 3 + 15 + 3)

--- a/src/tests/test_frame_hmm.py
+++ b/src/tests/test_frame_hmm.py
@@ -387,6 +387,64 @@ def test_a_noncanonical_intron_is_not_decoded_as_an_intron():
         assert (intron[:2], intron[-2:]) in (("GT", "AG"), ("GC", "AG"))
 
 
+def test_at_ac_intron_requires_opt_in():
+    """U12-type AT-AC introns are only decodable once GT_AG.AT_AC is enabled;
+    a donor from one splice motif group must never resume through another
+    group's acceptor."""
+    rng = np.random.default_rng(11)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    intron_start = 2000 + 200 + 50
+    intron_len = 200
+    sequence = (
+        sequence[:intron_start]
+        + "AT"
+        + sequence[intron_start + 2 : intron_start + intron_len - 2]
+        + "AC"
+        + sequence[intron_start + intron_len :]
+    )
+    codes = fh.encode_sequence(sequence)
+    probs = emissions_from(labels, 0.9)
+
+    # Without AT_AC, the true AT-AC intron is structurally unreachable, so the
+    # decoder falls back to whatever nearby canonical (GT-AG/GC-AG) intron
+    # best explains the emissions -- never the planted AT-AC one.
+    default = fh.frame_aware_decode(probs, codes, plant_matrix())
+    default_introns = decoded_introns(sequence, default)
+    assert default_introns, "expected the decoder to still find some intron"
+    for intron in default_introns:
+        assert (intron[:2], intron[-2:]) in (("GT", "AG"), ("GC", "AG"))
+
+    extended = fh.frame_aware_decode(
+        probs, codes, plant_matrix(), splice_motif_groups=(fh.GT_AG, fh.AT_AC)
+    )
+    introns = decoded_introns(sequence, extended)
+    assert introns, "expected the AT-AC intron to be decodable once enabled"
+    assert (introns[0][:2], introns[0][-2:]) == ("AT", "AC")
+    for coding in coding_sequences(sequence, extended):
+        assert is_valid_orf(coding)
+
+
+def test_splice_motif_groups_do_not_cross_pair():
+    """A GT donor may only resume through an AG acceptor, and an AT donor only
+    through AC, even when both groups are enabled -- donor and acceptor come
+    from the same sub-chain, never mixed across groups."""
+    states = fh.build_states(splice_motif_groups=(fh.GT_AG, fh.AT_AC))
+    edges = fh.build_edges(plant_matrix(), splice_motif_groups=(fh.GT_AG, fh.AT_AC))
+    fh.validate_edges(edges, fh.build_mask_table(), states)
+
+    by_name = {state.name: i for i, state in enumerate(states)}
+    outgoing: dict[int, list[int]] = {}
+    for source, destination, _ in edges:
+        outgoing.setdefault(source, []).append(destination)
+
+    gtag_body = by_name["intron_p2_gtag_body"]
+    atac_body = by_name["intron_p2_atac_body"]
+    gtag_acceptor_1 = by_name["intron_p2_gtag_a1"]
+    atac_acceptor_1 = by_name["intron_p2_atac_a1"]
+    assert outgoing[gtag_body] == [gtag_body, gtag_acceptor_1]
+    assert outgoing[atac_body] == [atac_body, atac_acceptor_1]
+
+
 def test_mismatched_sequence_length_is_rejected():
     rng = np.random.default_rng(5)
     sequence, labels = build_locus(rng, VALID_CODING, split=50)

--- a/src/tests/test_frame_hmm.py
+++ b/src/tests/test_frame_hmm.py
@@ -445,6 +445,31 @@ def test_splice_motif_groups_do_not_cross_pair():
     assert outgoing[atac_body] == [atac_body, atac_acceptor_1]
 
 
+def test_utr5_intron_resume_uses_measured_transition_ratio():
+    """Exiting a 5' UTR intron into more UTR vs. straight into the start codon
+    must split by the measured UTR5->UTR5 / UTR5->CDS ratio, not an arbitrary
+    50/50 -- regression test for a fix from a hardcoded flat split."""
+    matrix = plant_matrix()
+    # The real data isn't close to 50/50; if it ever were, this test wouldn't
+    # be able to tell a correct ratio-based split from a coincidental flat one.
+    assert matrix[U5, U5] == pytest.approx(0.9945, abs=0.01)
+    assert matrix[U5, CDS] == pytest.approx(0.0046, abs=0.01)
+
+    states = fh.build_states()
+    edges = fh.build_edges(matrix)
+    by_name = {state.name: i for i, state in enumerate(states)}
+    acceptor_2 = by_name["intron_utr5_gtag_a2"]
+
+    weights = {
+        states[destination].name: weight
+        for source, destination, weight in edges
+        if source == acceptor_2 and states[destination].name in ("utr5", "start_a")
+    }
+    total = matrix[U5, U5] + matrix[U5, CDS]
+    assert weights["utr5"] == pytest.approx(matrix[U5, U5] / total)
+    assert weights["start_a"] == pytest.approx(matrix[U5, CDS] / total)
+
+
 def test_mismatched_sequence_length_is_rejected():
     rng = np.random.default_rng(5)
     sequence, labels = build_locus(rng, VALID_CODING, split=50)

--- a/src/tests/test_frame_hmm.py
+++ b/src/tests/test_frame_hmm.py
@@ -1,0 +1,418 @@
+"""Tests for frame-aware, sequence-constrained HMM decoding."""
+
+import numpy as np
+import pytest
+
+from src import frame_hmm as fh
+from src.modeling import token_transition_probs
+
+IG, IN, U5, CDS, U3 = range(5)
+STOPS = {"TAA", "TAG", "TGA"}
+
+
+def plant_matrix() -> np.ndarray:
+    return token_transition_probs(
+        remove_incomplete_features=True, domain="plant"
+    ).values
+
+
+def random_sequence(rng: np.random.Generator, n: int) -> str:
+    return "".join(rng.choice(list("ACGT"), n))
+
+
+def emissions_from(labels: np.ndarray, confidence: float) -> np.ndarray:
+    """Per-base feature probabilities that put `confidence` on the given labels."""
+    probs = np.full((len(labels), 5), (1.0 - confidence) / 4.0)
+    probs[np.arange(len(labels)), labels] = confidence
+    return probs
+
+
+def coding_sequences(sequence: str, labels: np.ndarray) -> list[str]:
+    """Concatenate CDS-labelled bases per gene, splitting genes on intergenic runs."""
+    genes: list[str] = []
+    current: list[str] = []
+    in_gene = False
+    for base, label in zip(sequence, labels):
+        if label == IG:
+            if in_gene:
+                genes.append("".join(current))
+                current, in_gene = [], False
+            continue
+        in_gene = True
+        if label == CDS:
+            current.append(base)
+    if in_gene:
+        genes.append("".join(current))
+    return [gene for gene in genes if gene]
+
+
+def is_valid_orf(seq: str) -> bool:
+    return (
+        len(seq) >= 6
+        and len(seq) % 3 == 0
+        and seq.startswith("ATG")
+        and seq[-3:] in STOPS
+        and not any(seq[i : i + 3] in STOPS for i in range(3, len(seq) - 3, 3))
+    )
+
+
+# -------------------------------------------------------------------------------------------------
+# Synthetic locus
+# -------------------------------------------------------------------------------------------------
+
+
+def build_locus(
+    rng: np.random.Generator, coding: str, split: int, intron_len: int = 200
+):
+    """Lay a coding sequence out over two exons and return (sequence, labels)."""
+    exon1, exon2 = coding[:split], coding[split:]
+    intron = "GT" + random_sequence(rng, intron_len - 4) + "AG"
+    sequence = (
+        random_sequence(rng, 2000)
+        + random_sequence(rng, 200)
+        + exon1
+        + intron
+        + exon2
+        + random_sequence(rng, 200)
+        + random_sequence(rng, 2000)
+    )
+    labels = np.array(
+        [IG] * 2000
+        + [U5] * 200
+        + [CDS] * len(exon1)
+        + [IN] * intron_len
+        + [CDS] * len(exon2)
+        + [U3] * 200
+        + [IG] * 2000
+    )
+    assert len(sequence) == len(labels)
+    return sequence, labels
+
+
+VALID_CODING = "ATG" + "GCT" * 28 + "TAA"  # 90 nt, 29 residues
+
+
+# -------------------------------------------------------------------------------------------------
+# State graph
+# -------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("domain", ["plant", "animal"])
+@pytest.mark.parametrize("remove_incomplete", [True, False])
+def test_expanded_graph_is_a_valid_probability_model(domain, remove_incomplete):
+    """Expanded successors that share a feature weight must be mutually exclusive,
+    so that no state can emit more than unit probability at any base."""
+    matrix = token_transition_probs(
+        remove_incomplete_features=remove_incomplete, domain=domain
+    ).values
+    edges = fh.build_edges(matrix)
+    fh.validate_edges(edges, fh.build_mask_table())  # raises if violated
+
+    mask_table = fh.build_mask_table()
+    outgoing: dict[int, list[tuple[int, float]]] = {}
+    for source, destination, weight in edges:
+        outgoing.setdefault(source, []).append((destination, weight))
+    for source, successors in outgoing.items():
+        for base in range(fh.N_BASE_CODES):
+            total = sum(
+                weight
+                for destination, weight in successors
+                if mask_table[fh.STATES[destination].mask, base]
+            )
+            assert total <= 1.0 + 1e-9, fh.STATES[source].name
+
+
+def test_every_state_is_connected():
+    edges = fh.build_edges(plant_matrix())
+    sources = {source for source, _, _ in edges}
+    destinations = {destination for _, destination, _ in edges}
+    assert sources == set(range(fh.N_STATES))
+    assert destinations == set(range(fh.N_STATES))
+
+
+def test_mask_table_treats_ambiguous_bases_conservatively():
+    table = fh.build_mask_table()
+    # An N can never be read as a specific base ...
+    assert not table[fh.MASK_IS_A, fh.BASE_OTHER]
+    assert not table[fh.MASK_IS_T, fh.BASE_OTHER]
+    assert not table[fh.MASK_IS_G, fh.BASE_OTHER]
+    assert not table[fh.MASK_IS_AG, fh.BASE_OTHER]
+    # ... but it also never completes a stop codon
+    assert table[fh.MASK_NOT_A, fh.BASE_OTHER]
+    assert table[fh.MASK_NOT_AG, fh.BASE_OTHER]
+
+
+def test_sequence_encoding_is_case_insensitive_and_reversible():
+    sequence = "ACGTNacgtn"
+    codes = fh.encode_sequence(sequence)
+    assert list(codes[:5]) == list(codes[5:])
+    assert list(codes[:5]) == [
+        fh.BASE_A,
+        fh.BASE_C,
+        fh.BASE_G,
+        fh.BASE_T,
+        fh.BASE_OTHER,
+    ]
+
+    rng = np.random.default_rng(7)
+    sequence = random_sequence(rng, 500)
+    complement = str.maketrans("ACGT", "TGCA")
+    expected = fh.encode_sequence(sequence.translate(complement)[::-1])
+    assert np.array_equal(
+        fh.reverse_complement_codes(fh.encode_sequence(sequence)), expected
+    )
+
+
+# -------------------------------------------------------------------------------------------------
+# Decoding
+# -------------------------------------------------------------------------------------------------
+
+
+def test_confident_predictions_are_recovered_exactly():
+    rng = np.random.default_rng(0)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    decoded = fh.frame_aware_decode(
+        emissions_from(labels, 0.9), fh.encode_sequence(sequence), plant_matrix()
+    )
+    assert np.array_equal(decoded, labels)
+
+
+def test_frame_is_carried_across_an_intron():
+    """The exon boundary falls mid-codon, so recovering the ORF requires the
+    reading frame to survive the intron."""
+    rng = np.random.default_rng(1)
+    for split in (49, 50, 51):  # each of the three codon positions
+        sequence, labels = build_locus(rng, VALID_CODING, split=split)
+        decoded = fh.frame_aware_decode(
+            emissions_from(labels, 0.9), fh.encode_sequence(sequence), plant_matrix()
+        )
+        assert coding_sequences(sequence, decoded) == [VALID_CODING], f"{split=}"
+
+
+def test_sloppy_cds_boundaries_snap_back_to_the_true_orf():
+    """The characteristic failure of the unconstrained decoder is a CDS that
+    bleeds a base or two into the flanking UTRs."""
+    rng = np.random.default_rng(2)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    sloppy = labels.copy()
+    sloppy[2198:2200] = CDS  # eats into the 5' UTR
+    sloppy[2290:2292] = CDS  # eats into the 3' UTR
+
+    decoded = fh.frame_aware_decode(
+        emissions_from(sloppy, 0.9), fh.encode_sequence(sequence), plant_matrix()
+    )
+    assert coding_sequences(sequence, decoded) == [VALID_CODING]
+
+
+def test_unconstrained_decoder_does_not_survive_the_same_input():
+    """Guards the premise of this module: the 5-state decoder really does emit
+    an untranslatable CDS for the input above."""
+    from src.sequence import viterbi_decode
+
+    rng = np.random.default_rng(2)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    sloppy = labels.copy()
+    sloppy[2198:2200] = CDS
+    sloppy[2290:2292] = CDS
+
+    decoded = viterbi_decode(
+        emission_probs=emissions_from(sloppy, 0.9), transition_matrix=plant_matrix()
+    )
+    assert not all(is_valid_orf(seq) for seq in coding_sequences(sequence, decoded))
+
+
+def test_in_frame_stop_codons_are_never_emitted():
+    """A CDS carrying an in-frame stop must not be decodable as coding, even
+    when the emissions insist on it."""
+    rng = np.random.default_rng(3)
+    # TAA sits in frame, 12 nt into the coding sequence
+    poisoned = "ATG" + "GCT" * 3 + "TAA" + "GCT" * 24 + "TGA"
+    sequence, labels = build_locus(rng, poisoned, split=50)
+
+    decoded = fh.frame_aware_decode(
+        emissions_from(labels, 0.9), fh.encode_sequence(sequence), plant_matrix()
+    )
+    for coding in coding_sequences(sequence, decoded):
+        assert is_valid_orf(coding)
+        assert coding != poisoned
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_every_decoded_cds_is_a_valid_orf(seed):
+    """The structural guarantee: whatever the emissions say, any coding sequence
+    the decoder emits translates cleanly."""
+    rng = np.random.default_rng(100 + seed)
+    coding = "ATG" + "".join(
+        rng.choice(["GCT", "AAA", "TTT", "CCG", "GGA", "TCA"]) for _ in range(40)
+    )
+    coding += "TAG"
+    sequence, labels = build_locus(rng, coding, split=int(rng.integers(20, 100)))
+
+    # Degrade the emissions: low confidence plus noise, so the decoder is not
+    # simply reading off a clean answer.
+    probs = emissions_from(labels, 0.55) + rng.random((len(labels), 5)) * 0.2
+    probs /= probs.sum(axis=1, keepdims=True)
+
+    decoded = fh.frame_aware_decode(probs, fh.encode_sequence(sequence), plant_matrix())
+    genes = coding_sequences(sequence, decoded)
+    assert genes, "expected at least one coding region"
+    for gene in genes:
+        assert is_valid_orf(gene), f"invalid ORF decoded: {gene[:30]}...{gene[-9:]}"
+
+
+def test_minus_strand_decoding_recovers_a_reverse_strand_gene():
+    """Exercise the transformation detect_intervals applies to the minus strand:
+    the logits are decoded reversed, so the sequence must be reverse
+    complemented to stay in register.  A gene on the minus strand must come back
+    out at the right coordinates."""
+    rng = np.random.default_rng(4)
+    locus, locus_labels = build_locus(rng, VALID_CODING, split=50)
+
+    # The same gene, now lying on the minus strand of the chromosome
+    complement = str.maketrans("ACGT", "TGCA")
+    chromosome = locus.translate(complement)[::-1]
+    chromosome_labels = locus_labels[::-1].copy()
+
+    codes = fh.encode_sequence(chromosome)
+    probs = emissions_from(chromosome_labels, 0.9)
+
+    # `np.flip` mirrors exactly what detect_intervals does for the minus strand
+    decoded = np.flip(
+        fh.frame_aware_decode(
+            np.flip(probs, axis=0),
+            fh.reverse_complement_codes(codes),
+            plant_matrix(),
+        ),
+        axis=0,
+    )
+
+    assert np.array_equal(decoded, chromosome_labels)
+    # and the coding sequence read off the minus strand is the true ORF
+    coding = "".join(
+        base for base, label in zip(chromosome, decoded) if label == CDS
+    ).translate(complement)[::-1]
+    assert coding == VALID_CODING
+
+
+def decoded_introns(sequence: str, labels: np.ndarray) -> list[str]:
+    """Every maximal run of intron-labelled bases, as a sequence."""
+    runs: list[str] = []
+    current: list[str] = []
+    for base, label in zip(sequence, labels):
+        if label == IN:
+            current.append(base)
+        elif current:
+            runs.append("".join(current))
+            current = []
+    if current:
+        runs.append("".join(current))
+    return runs
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_decoded_introns_are_always_canonical(seed):
+    """Without a splice-site constraint the decoder escapes an in-frame stop by
+    inventing a two-base intron.  Every emitted intron must carry a real donor
+    and acceptor."""
+    rng = np.random.default_rng(200 + seed)
+    coding = (
+        "ATG"
+        + "".join(rng.choice(["GCT", "AAA", "TTT", "CCG"]) for _ in range(40))
+        + "TAG"
+    )
+    sequence, labels = build_locus(rng, coding, split=int(rng.integers(20, 100)))
+    probs = emissions_from(labels, 0.55) + rng.random((len(labels), 5)) * 0.2
+    probs /= probs.sum(axis=1, keepdims=True)
+
+    decoded = fh.frame_aware_decode(probs, fh.encode_sequence(sequence), plant_matrix())
+    introns = decoded_introns(sequence, decoded)
+    assert introns, "expected at least one intron"
+    for intron in introns:
+        assert len(intron) >= fh.MIN_INTRON_LENGTH
+        assert (intron[:2], intron[-2:]) in (("GT", "AG"), ("GC", "AG")), intron[:8]
+
+
+def test_minimum_intron_length_is_enforced():
+    """A canonical donor alone is not enough: GT...AG occurs by chance every few
+    hundred bases, so a short intron must also be structurally unreachable."""
+    rng = np.random.default_rng(9)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50, intron_len=12)
+    probs = emissions_from(labels, 0.9)
+    codes = fh.encode_sequence(sequence)
+
+    # Permitted when the minimum is relaxed to the structural floor
+    relaxed = fh.frame_aware_decode(
+        probs, codes, plant_matrix(), min_intron_length=fh.STRUCTURAL_MIN_INTRON_LENGTH
+    )
+    assert [len(i) for i in decoded_introns(sequence, relaxed)] == [12]
+
+    # Excluded at the default minimum, even though the emissions ask for it
+    strict = fh.frame_aware_decode(probs, codes, plant_matrix())
+    for intron in decoded_introns(sequence, strict):
+        assert len(intron) >= fh.DEFAULT_MIN_INTRON_LENGTH
+    for coding in coding_sequences(sequence, strict):
+        assert is_valid_orf(coding)
+
+
+@pytest.mark.parametrize("min_intron_length", [5, 20, 40])
+def test_backpointer_memory_does_not_grow_with_minimum_intron_length(min_intron_length):
+    """The mandatory body states have one predecessor each, so raising the
+    minimum intron length must cost states but not per-position memory."""
+    states = fh.build_states(min_intron_length)
+    edges = fh.build_edges(plant_matrix(), min_intron_length)
+    fh.validate_edges(edges, fh.build_mask_table(), states)
+    index = fh.build_predecessor_csr(edges, len(states))
+
+    assert len(states) == 20 + 8 * min_intron_length
+    assert index.n_branch_columns == 24
+    # every non-branching state must know its unique predecessor
+    for j in range(len(states)):
+        assert (index.branch_column[j] >= 0) != (index.sole_predecessor[j] >= 0)
+
+
+def test_a_noncanonical_intron_is_not_decoded_as_an_intron():
+    rng = np.random.default_rng(8)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    # Break the donor dinucleotide of the only intron
+    intron_start = 2000 + 200 + 50
+    sequence = sequence[:intron_start] + "AA" + sequence[intron_start + 2 :]
+
+    decoded = fh.frame_aware_decode(
+        emissions_from(labels, 0.9), fh.encode_sequence(sequence), plant_matrix()
+    )
+    assert decoded[intron_start] != IN
+    for intron in decoded_introns(sequence, decoded):
+        assert (intron[:2], intron[-2:]) in (("GT", "AG"), ("GC", "AG"))
+
+
+def test_mismatched_sequence_length_is_rejected():
+    rng = np.random.default_rng(5)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    with pytest.raises(ValueError, match="does not match"):
+        fh.frame_aware_decode(
+            emissions_from(labels, 0.9),
+            fh.encode_sequence(sequence[:-10]),
+            plant_matrix(),
+        )
+
+
+def test_returning_expanded_states_maps_back_to_features():
+    rng = np.random.default_rng(6)
+    sequence, labels = build_locus(rng, VALID_CODING, split=50)
+    codes = fh.encode_sequence(sequence)
+    features = fh.frame_aware_decode(emissions_from(labels, 0.9), codes, plant_matrix())
+    states = fh.frame_aware_decode(
+        emissions_from(labels, 0.9), codes, plant_matrix(), return_states=True
+    )
+    state_feature = np.array([state.feature for state in fh.STATES])
+    assert np.array_equal(state_feature[states], features)
+
+    # The start codon really is decoded through the dedicated start states
+    coding_start = int(np.argmax(features == CDS))
+    assert [fh.STATES[s].name for s in states[coding_start : coding_start + 3]] == [
+        "start_a",
+        "start_t",
+        "start_g",
+    ]
+    coding_end = len(features) - 1 - int(np.argmax((features == CDS)[::-1]))
+    assert fh.STATES[states[coding_end]].name in ("stop_end_a", "stop_end_g")

--- a/src/tests/test_frame_hmm.py
+++ b/src/tests/test_frame_hmm.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from src import frame_hmm as fh
+
+pytest.importorskip("torch")
 from src.modeling import token_transition_probs
 
 IG, IN, U5, CDS, U3 = range(5)

--- a/uv.lock
+++ b/uv.lock
@@ -398,7 +398,7 @@ http = [
 
 [[package]]
 name = "genecad"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "biopython" },


### PR DESCRIPTION
Fix non-translatable CDS predictions from Viterbi decoder

1. Extended 5-state HMM to enforce reading frame constraints during decoding (`frame_hmm.py`).
2. Added `fix_orf.py` post-processing to repair start/stop boundaries up to `--orf-max-shift`.
3. Flag unresolvable transcripts as `partial=true` instead of forcing invalid ORFs.
4. Added 46 unit tests in `test_frame_hmm.py` and `test_fix_orf.py.`