### PR TITLE
frame-aware decoding and downstream ORF correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ Refer to the `docs/` folder for full parameter lists for each step/script.
 4. [Export GFFs](docs/export_gff.md) - `scripts/export_gff.py` - Converts the genomic intervals to GFF format.
 5. [Filter GFFs](docs/filter_raw_gff.md) - `scripts/filter_raw_gff.py` - Removes fragmented or excessively short gene models.
 6. [Merge Chromosme GFFs](docs/merge_gff.md) - `scripts/merge_gff.py` - Merges per-chromosome GFF files into a single unified file.
-7. [Refine with ReelProtein](docs/refine.md) - `scripts/refine.py` - **REQUIRES GPU** - Uses ReelProtein to evaluate  and filter gene models for likely
+7. [Repair ORFs](docs/fix_orf.md) - `scripts/fix_orf.py` - Repairs CDS boundaries against the genome sequence so each transcript is a valid, translatable ORF.
+8. [Refine with ReelProtein](docs/refine.md) - `scripts/refine.py` - **REQUIRES GPU** - Uses ReelProtein to evaluate  and filter gene models for likely
 protein functionality and merges gene fragments.
 
 #### Outputs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GeneCAD: Plant Genome Annotation with a DNA Foundation Model
 
-![](https://img.shields.io/badge/version-0.4.0-blue)
+![](https://img.shields.io/badge/version-0.4.2-blue)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/plantcad/genecad/actions/workflows/ci.yaml/badge.svg)](https://github.com/plantcad/genecad/actions/workflows/ci.yaml)
 [![bioRxiv](https://img.shields.io/badge/bioRxiv-10.1101/2025.10.31.685877-b31b1b.svg)](https://doi.org/10.1101/2025.10.31.685877)

--- a/docs/create_manifest.md
+++ b/docs/create_manifest.md
@@ -1,6 +1,6 @@
 # Detailed documentation for create_manifest.py
 
-Optional step between [1/7] and [2/7] of the prediction pipeline creates a keyfile that
+Optional step between [1/8] and [2/8] of the prediction pipeline creates a keyfile that
 coordinates processing multiple contigs at the same time.
 
 ```

--- a/docs/detect_intervals.md
+++ b/docs/detect_intervals.md
@@ -1,6 +1,6 @@
 # Detailed documentation for detect_intervals.py
 
-Step [3/7] of the prediction pipeline converts base-level classifications to genomic regions,
+Step [3/8] of the prediction pipeline converts base-level classifications to genomic regions,
 such as CDS and UTR exons using the viterbi algorithm and domain-specific
  transition probabilities.
 

--- a/docs/export_gff.md
+++ b/docs/export_gff.md
@@ -1,6 +1,6 @@
 # Detailed documentation for export_gff.py
 
-Step [4/7] of the prediction pipeline converts predicted intervals into a GFF3 formatted file.
+Step [4/8] of the prediction pipeline converts predicted intervals into a GFF3 formatted file.
 
 ```
 python export_gff.py \

--- a/docs/extract_fasta.md
+++ b/docs/extract_fasta.md
@@ -1,6 +1,6 @@
 # Detailed documentation for extract_fasta.py
 
-Step [1/7] of the prediction pipeline prepares fasta sequences for inference.
+Step [1/8] of the prediction pipeline prepares fasta sequences for inference.
 
 ```
 python extract_fasta.py \

--- a/docs/filter_raw_gff.md
+++ b/docs/filter_raw_gff.md
@@ -1,6 +1,6 @@
 # Detailed documentation for filter_raw_gff.py
 
-Step [5/7] of the prediction pipeline applies a basic set of filters to raw GeneCAD output, removing
+Step [5/8] of the prediction pipeline applies a basic set of filters to raw GeneCAD output, removing
 gene models and features that are abnormally short or that lack key components, such
 as coding sequences or UTRs.
 

--- a/docs/fix_orf.md
+++ b/docs/fix_orf.md
@@ -1,0 +1,67 @@
+# Detailed documentation for fix_orf.py
+
+Step [7/8] of the prediction pipeline repairs CDS boundaries in GeneCAD predictions against the
+genome sequence, so that each transcript's CDS is a valid, translatable ORF (starts on ATG, ends
+on a stop codon, is a multiple of three, and contains no in-frame stop).
+
+> [!NOTE]
+> GeneCAD predicts per-base feature labels without reading the underlying nucleotide sequence, so
+> a predicted CDS is not guaranteed to already be a valid ORF.
+
+```
+python fix_orf.py \
+--input-gff genecad_raw.gff \
+--input-fasta genome.fa \
+--output-gff genecad_orf.gff \
+--report genecad_orf_report.tsv
+```
+
+### Parameters
+
+* `--input-gff`, `-i` - Input GFF3 file. Output from `merge_gff.py`
+* `--input-fasta`, `-f` - Genome FASTA file
+* `--output-gff`, `-o` - Output GFF3 file
+* `--max-shift` - Maximum movement (nt, in spliced transcript coordinates) allowed for the TIS and
+for the TTS. Bounds how far a repair may depart from the model's prediction, and prevents long CDS
+being truncated to short ORFs. Default 300.
+* `--min-protein-length` - Minimum protein length in residues (excluding the stop codon) for a
+repair. Default 10.
+* `--allow-noncanonical-introns` - Flag. Attempt repair even when the transcript has non-canonical
+introns. Off by default: an ORF built on untrustworthy splice calls is not trustworthy.
+* `--no-fix-weak-starts` - Flag. Disables Kozak-context re-ranking of already-valid but
+suspiciously short first exons. On by default.
+* `--weak-start-threshold` - First coding exon length (nt) below which alternative start codons are
+considered, when weak-start fixing is not disabled. Default 9.
+* `--kozak-margin` - Minimum Kozak log2-odds advantage an alternative start codon must have over
+the original to trigger a switch. Used as the floor value that per-genome calibration raises from,
+unless `--no-calibrate-kozak-margin` is set, in which case it is used as-is. Default 3.0.
+* `--no-calibrate-kozak-margin` - Flag. Uses `--kozak-margin` as a fixed value for every genome
+instead of raising it per genome from that genome's own confident (unambiguous) start codons. On
+by default.
+* `--weak-kozak-threshold` - Kozak log2-odds score below which even the best candidate start is
+flagged (`orf_issue=weak_kozak_support`) rather than kept silently. Default 5.0.
+* `--report` - Optional TSV path for per-transcript status output.
+
+### A Note on Repair Constraints
+
+The repair is deliberately constrained so that it cannot invent gene structure:
+
+1. Exon structure is frozen. Every splice junction in the output is a junction the model itself
+predicted; introns are never moved, split, merged, or created.
+2. Only the TIS and TTS move, and only within the spliced mRNA — i.e. only across sequence the
+model already called exonic. A repair can relabel predicted UTR as CDS or predicted CDS as UTR,
+but it can never pull in intronic or intergenic sequence.
+3. Internal introns must be canonical (GT-AG / GC-AG / AT-AC) for a repair to be attempted, unless
+`--allow-noncanonical-introns` is set.
+4. The repaired ORF must be fully valid: ATG start, length divisible by 3, no in-frame stop, stop
+codon end.
+5. Among valid solutions, the one closest to the original prediction wins (minimum total boundary
+movement), capped by `--max-shift`.
+
+Transcripts that cannot be repaired under these rules are passed through unchanged and flagged
+(`partial=true`, `orf_issue=…`, plus GFF3 `start_range`/`end_range`) so downstream steps can filter
+them.
+
+### Next Step
+
+`python refine.py` [Refine Documentation](refine.md)

--- a/docs/merge_gff.md
+++ b/docs/merge_gff.md
@@ -1,6 +1,6 @@
 # Detailed documentation for merge_gff.py
 
-Step [6/7] of the prediction pipeline merges a list of single-chromosome GFF files into one GFF file.
+Step [6/8] of the prediction pipeline merges a list of single-chromosome GFF files into one GFF file.
 
 ```
 python merge_gff.py \
@@ -20,4 +20,4 @@ specified directly.
 
 ### Next Step
 
-`python refine.py` [Refine Documentation](refine.md)
+`python fix_orf.py` [Fix ORF Documentation](fix_orf.md)

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -1,6 +1,6 @@
 # Detailed documenation for predict.py
 
-Step [2/7] of the prediction pipeline performs multiclass classification on each base pair in the input sequence.
+Step [2/8] of the prediction pipeline performs multiclass classification on each base pair in the input sequence.
 
 > [NOTE!]
 > This script requires a CUDA GPU

--- a/docs/refine.md
+++ b/docs/refine.md
@@ -1,6 +1,6 @@
 # Detailed documentation for refine.py
 
-Step [7/7] of the prediction pipeline refines GeneCAD predictions by removing gene models that are unlikely
+Step [8/8] of the prediction pipeline refines GeneCAD predictions by removing gene models that are unlikely
 to be functional protein coding genes using ReelProtein, and by attempting to merge fragmented gene models.
 
 > [!NOTE]
@@ -8,14 +8,14 @@ to be functional protein coding genes using ReelProtein, and by attempting to me
 
 ```
 python refine.py \
---input-gff genecad_raw.gff \
+--input-gff genecad_orf.gff \
 --input-fasta path/to/fasta.fa
 --output-gff genecad_filtered.gff
 ```
 
 ### Parameters
 
-* `--input-gff`, `-i` - Input GFF file. Output from `merge_gff.py`
+* `--input-gff`, `-i` - Input GFF file. Output from `fix_orf.py`
 * `--input-fasta` `-f` - Input FASTA file for the sample
 * `--output-gff`, `-o` - Output GFF file
 * `--reelprotein-model-path` - HuggingFace repository ID for the ReelProtein model used to

--- a/pipelines/experiments/intergenic_bias_sweep/jregia/sweep.sh
+++ b/pipelines/experiments/intergenic_bias_sweep/jregia/sweep.sh
@@ -8,10 +8,12 @@ set -euo pipefail
 #   - gffcompare must be on PATH
 #
 # Usage:
-#   bash pipelines/experiments/intergenic_bias_sweep/sweep.sh
+#   OUTPUT_DIR=... REF_GFF=... INPUT_FASTA=... \
+#   bash pipelines/experiments/intergenic_bias_sweep/jregia/sweep.sh
 
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR must be set}"
 REF_GFF="${REF_GFF:?REF_GFF must be set}"
+INPUT_FASTA="${INPUT_FASTA:?INPUT_FASTA must be set (the chr1.fa used for prediction; enables frame-aware decoding)}"
 GFFCOMPARE="${GFFCOMPARE:-$WORK/repos/misc/gffcompare/gffcompare}"
 REQUIRE_UTRS="${REQUIRE_UTRS:-yes}"
 
@@ -37,42 +39,35 @@ for BIAS in $BIAS_VALUES; do
     SWEEP_DIR="$PIPELINE_DIR/sweep_bias_${BIAS}"
     mkdir -p "$SWEEP_DIR"
 
-    # Step 1: Detect intervals
-    python scripts/predict.py detect_intervals \
-        --input-dir "$PREDICTIONS_ZARR" \
-        --output "$SWEEP_DIR/intervals.zarr" \
-        --decoding-methods "direct,viterbi" \
-        --remove-incomplete-features yes \
+    # Step 1: Detect intervals (frame-aware, since --input-fasta is given).
+    # Incomplete features are removed by default (pass --keep-incomplete-features to keep them).
+    python scripts/detect_intervals.py \
+        -i "$PREDICTIONS_ZARR" \
+        -o "$SWEEP_DIR/intervals.zarr" \
+        --domain plant \
+        --input-fasta "$INPUT_FASTA" \
         --intergenic-bias "$BIAS"
 
-    # Step 2: Export raw GFF
-    python scripts/predict.py export_gff \
-        --input "$SWEEP_DIR/intervals.zarr" \
-        --output "$SWEEP_DIR/predictions__raw.gff" \
-        --decoding-method viterbi \
-        --min-transcript-length 3 \
-        --strip-introns yes
+    # Step 2: Export raw GFF (introns are stripped by default)
+    python scripts/export_gff.py \
+        -i "$SWEEP_DIR/intervals.zarr" \
+        -o "$SWEEP_DIR/predictions__raw.gff" \
+        --min-transcript-length 3
 
-    # Step 3: Filter small features
-    python scripts/gff.py filter_to_min_feature_length \
-        --input "$SWEEP_DIR/predictions__raw.gff" \
-        --output "$SWEEP_DIR/predictions__feat_len_2.gff" \
+    REQUIRE_UTRS_FLAG=()
+    [ "$REQUIRE_UTRS" = "yes" ] && REQUIRE_UTRS_FLAG=(--require-utrs)
+
+    # Step 3: Filter small features, short genes, and (optionally) require
+    # UTRs -- all three filters run in one pass, in that fixed order.
+    python scripts/filter_raw_gff.py \
+        -i "$SWEEP_DIR/predictions__raw.gff" \
+        -o "$SWEEP_DIR/predictions.gff" \
         --feature-types "five_prime_UTR,three_prime_UTR,CDS" \
-        --min-length 2
+        --min-feature-length 2 \
+        --min-gene-length 30 \
+        "${REQUIRE_UTRS_FLAG[@]}"
 
-    # Step 4: Filter short genes
-    python scripts/gff.py filter_to_min_gene_length \
-        --input "$SWEEP_DIR/predictions__feat_len_2.gff" \
-        --output "$SWEEP_DIR/predictions__gene_len_30.gff" \
-        --min-length 30
-
-    # Step 5: Filter to valid genes
-    python scripts/gff.py filter_to_valid_genes \
-        --input "$SWEEP_DIR/predictions__gene_len_30.gff" \
-        --output "$SWEEP_DIR/predictions.gff" \
-        --require-utrs "$REQUIRE_UTRS"
-
-    # Step 6: Run gffcompare
+    # Step 4: Run gffcompare
     "$GFFCOMPARE" \
         -r "$REF_GFF" \
         -C -o "$SWEEP_DIR/gffcompare" \

--- a/pipelines/experiments/intergenic_bias_sweep/zmays/sweep.sh
+++ b/pipelines/experiments/intergenic_bias_sweep/zmays/sweep.sh
@@ -85,10 +85,12 @@ set -euo pipefail
 # Usage:
 #   OUTPUT_DIR=$SCRATCH/tmp/zmays/output \
 #   REF_GFF=$SCRATCH/tmp/zmays/chr1.gff3 \
+#   INPUT_FASTA=$SCRATCH/tmp/zmays/chr1.fa \
 #   bash pipelines/experiments/intergenic_bias_sweep/zmays/sweep.sh
 
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR must be set}"
 REF_GFF="${REF_GFF:?REF_GFF must be set}"
+INPUT_FASTA="${INPUT_FASTA:?INPUT_FASTA must be set (the chr1.fa used for prediction; enables frame-aware decoding)}"
 GFFCOMPARE="${GFFCOMPARE:-$WORK/repos/misc/gffcompare/gffcompare}"
 
 PIPELINE_DIR="$OUTPUT_DIR/pipeline"
@@ -131,49 +133,42 @@ for BIAS in "${MY_BIAS[@]}"; do
     echo "Detecting intervals for bias=$BIAS"
     echo "========================================="
 
-    # Step 1: Detect intervals
-    python scripts/predict.py detect_intervals \
-        --input-dir "$PREDICTIONS_ZARR" \
-        --output "$BIAS_DIR/intervals.zarr" \
-        --decoding-methods "direct,viterbi" \
-        --remove-incomplete-features yes \
+    # Step 1: Detect intervals (frame-aware, since --input-fasta is given).
+    # Incomplete features are removed by default (pass --keep-incomplete-features to keep them).
+    python scripts/detect_intervals.py \
+        -i "$PREDICTIONS_ZARR" \
+        -o "$BIAS_DIR/intervals.zarr" \
+        --domain plant \
+        --input-fasta "$INPUT_FASTA" \
         --intergenic-bias "$BIAS"
 
-    # Step 2: Export raw GFF
-    python scripts/predict.py export_gff \
-        --input "$BIAS_DIR/intervals.zarr" \
-        --output "$BIAS_DIR/predictions__raw.gff" \
-        --decoding-method viterbi \
-        --min-transcript-length 3 \
-        --strip-introns yes
+    # Step 2: Export raw GFF (introns are stripped by default)
+    python scripts/export_gff.py \
+        -i "$BIAS_DIR/intervals.zarr" \
+        -o "$BIAS_DIR/predictions__raw.gff" \
+        --min-transcript-length 3
 
-    # Step 3: Filter small features (also UTR-independent)
-    python scripts/gff.py filter_to_min_feature_length \
-        --input "$BIAS_DIR/predictions__raw.gff" \
-        --output "$BIAS_DIR/predictions__feat_len_2.gff" \
-        --feature-types "five_prime_UTR,three_prime_UTR,CDS" \
-        --min-length 2
-
-    # Step 4: Filter short genes (also UTR-independent)
-    python scripts/gff.py filter_to_min_gene_length \
-        --input "$BIAS_DIR/predictions__feat_len_2.gff" \
-        --output "$BIAS_DIR/predictions__gene_len_30.gff" \
-        --min-length 30
-
-    # Steps 5-6 depend on REQUIRE_UTRS, loop over UTR settings
+    # Steps 3-4 depend on REQUIRE_UTRS, loop over UTR settings
     for UTRS in $UTRS_VALUES; do
         echo "--- bias=$BIAS, require_utrs=$UTRS ---"
 
         UTRS_DIR="$BIAS_DIR/utrs_${UTRS}"
         mkdir -p "$UTRS_DIR"
 
-        # Step 5: Filter to valid genes
-        python scripts/gff.py filter_to_valid_genes \
-            --input "$BIAS_DIR/predictions__gene_len_30.gff" \
-            --output "$UTRS_DIR/predictions.gff" \
-            --require-utrs "$UTRS"
+        REQUIRE_UTRS_FLAG=()
+        [ "$UTRS" = "yes" ] && REQUIRE_UTRS_FLAG=(--require-utrs)
 
-        # Step 6: Run gffcompare
+        # Step 3: Filter small features, short genes, and (optionally) require
+        # UTRs -- all three filters run in one pass, in that fixed order.
+        python scripts/filter_raw_gff.py \
+            -i "$BIAS_DIR/predictions__raw.gff" \
+            -o "$UTRS_DIR/predictions.gff" \
+            --feature-types "five_prime_UTR,three_prime_UTR,CDS" \
+            --min-feature-length 2 \
+            --min-gene-length 30 \
+            "${REQUIRE_UTRS_FLAG[@]}"
+
+        # Step 4: Run gffcompare
         "$GFFCOMPARE" \
             -r "$REF_GFF" \
             -C -o "$UTRS_DIR/gffcompare" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genecad"
-version = "0.4.1"
+version = "0.4.2"
 description = "GeneCAD: A long-context genome annotation model built on PlantCAD2"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -20,19 +20,27 @@ The repair is deliberately constrained so that it cannot invent gene structure:
 3.  Internal introns must be canonical (GT-AG / GC-AG / AT-AC) for a repair to
     be attempted.  If the model's own splice calls are not trustworthy, neither
     is any ORF built on top of them.  (Relax with --allow-noncanonical-introns.)
+    This applies to rule 6's weak-start switch too: a non-canonical intron
+    blocks the switch (but not the weak_kozak_support flag, which changes no
+    gene structure).
 4.  The repaired ORF must be fully valid: ATG start, length % 3 == 0, no
     in-frame stop, stop codon end.
 5.  Among valid solutions the one closest to the original prediction wins
     (minimum total boundary movement), and movement is capped by --max-shift.
     Truncating a long CDS down to a short ORF is therefore rejected: it would
     require a large 3' shift.
-6.  Even when the predicted CDS is already a valid ORF, if its first exon
-    is shorter than --weak-start-threshold, alternative start codons within
-    the same already-predicted exonic sequence are considered and the one
-    with the strongest Kozak-context support is preferred, provided it
-    beats the original by --kozak-margin. This still only relabels
-    predicted exonic sequence (rule 2 still applies) -- it never invents
-    new gene structure. Transcripts whose best candidate is still weak
+6.  Even when the predicted CDS is already a valid ORF, if its first *coding*
+    exon (i.e. the CDS portion of the first exon it overlaps, not counting any
+    5'UTR on that exon) is shorter than --weak-start-threshold, alternative
+    start codons within the same already-predicted exonic sequence are
+    considered and the one with the strongest Kozak-context support is
+    preferred, provided it beats the original by --kozak-margin. Candidates
+    are restricted to the original start's reading frame *and* to those
+    whose own forced stop is the original stop codon unchanged, so a switch
+    can only move the TIS -- it can never change the stop codon or the
+    encoded protein downstream of the new start. This still only relabels predicted
+    exonic sequence (rule 2 still applies) -- it never invents new gene
+    structure. Transcripts whose best candidate is still weak
     (--weak-kozak-threshold) are flagged (orf_issue=weak_kozak_support)
     rather than forced. Disable with --no-fix-weak-starts.
 
@@ -90,6 +98,10 @@ KOZAK_PWM_LOG_ODDS: tuple[tuple[float, float, float, float], ...] = (
     (-0.1478, 0.6393, 0.0373, -0.3954),
     (-0.3735, 0.2646, 0.4629, -0.1626),
 )
+# Background base composition the PWM above was fit against. Not read by
+# kozak_score(): KOZAK_PWM_LOG_ODDS is already log-odds (foreground/background),
+# so the background is already baked into those numbers. Kept only as fitting
+# provenance/documentation -- do not wire it into the scoring math.
 KOZAK_BACKGROUND: tuple[float, float, float, float] = (0.3170, 0.1830, 0.1830, 0.3170)
 
 # Consensus: AAAAAAATGGCGAAT  (positions -6..ATG..+6)
@@ -438,13 +450,33 @@ def find_best_start_by_kozak(
     max_shift: int,
     min_protein_length: int,
 ) -> tuple[int, int, float] | None:
-    """Best-Kozak-scoring valid ORF within max_shift of (cds_begin, cds_stop).
+    """Best-Kozak-scoring valid ORF within max_shift of (cds_begin, cds_stop),
+    among candidates that preserve both cds_begin's reading frame and
+    cds_stop exactly.
 
     Same candidate space as find_best_orf -- every in-frame ATG within the
     window, each with its forced downstream in-frame stop -- but ranked by
-    kozak_score() instead of boundary movement. Candidates whose Kozak
-    window falls outside the sequence (kozak_score returns None) are
-    skipped: there is nothing to compare.
+    kozak_score() instead of boundary movement, and restricted to
+    candidates that (a) share cds_begin's reading frame and (b) whose
+    forced downstream stop is cds_stop itself, unchanged. This repair only
+    re-picks *which* start codon within an already-valid ORF is used; it
+    must never change the reading frame or the stop codon, either of which
+    would silently replace the protein with an unrelated one chosen on 5'
+    evidence alone.
+
+    Both restrictions are necessary, not just the frame one: a same-frame
+    candidate upstream of cds_begin (still within the exonic sequence, e.g.
+    in the 5' UTR) is not guaranteed to reach cds_stop without hitting an
+    earlier in-frame stop first -- that region was never covered by the
+    original ORF's own validity check, so it may harbor a short, unrelated
+    upstream ORF (a real uORF, or just incidental sequence) that happens to
+    have a strong Kozak context purely because Kozak scoring only looks at
+    +/-6 nt around the ATG, independent of what follows. Requiring
+    stop == cds_stop explicitly rules those out, rather than relying on it
+    holding "naturally" -- confirmed against real genome-scale data that it
+    does not hold naturally for every same-frame candidate in the window.
+    Candidates whose Kozak window falls outside the sequence (kozak_score
+    returns None) are skipped: there is nothing to compare.
 
     Returns
     -------
@@ -458,12 +490,19 @@ def find_best_start_by_kozak(
 
     best: tuple[int, int, float] | None = None
     for begin in range(lo, hi):
+        if (begin - cds_begin) % 3 != 0:
+            continue
         if seq[begin : begin + 3] != START_CODON:
             continue
         stop_offset = next_stop[begin]
         if stop_offset < 0:
             continue
         stop = stop_offset + 3
+        if stop != cds_stop:
+            # The candidate's own downstream path hits an earlier (or
+            # later) in-frame stop than the original -- it is not a
+            # different start for the same ORF, it is a different ORF.
+            continue
         if stop - begin < 3 * (min_protein_length + 1):
             continue
         if abs(stop - cds_stop) > max_shift:
@@ -539,6 +578,20 @@ def rebuild_children(
     return records
 
 
+def has_noncanonical_introns(transcript: Transcript, chrom: str) -> bool:
+    """True if any of the transcript's introns has a non-canonical donor/acceptor pair."""
+    for intron_start, intron_end in transcript.introns():
+        if intron_end < intron_start:
+            return True
+        donor = chrom[intron_start - 1 : intron_start + 1].upper()
+        acceptor = chrom[intron_end - 2 : intron_end].upper()
+        if transcript.strand == "-":
+            donor, acceptor = revcomp(acceptor), revcomp(donor)
+        if (donor, acceptor) not in CANONICAL_SPLICE_PAIRS:
+            return True
+    return False
+
+
 def repair_transcript(
     transcript: Transcript,
     chrom: str,
@@ -596,8 +649,17 @@ def repair_transcript(
             alt = find_best_start_by_kozak(
                 seq, begin, stop, max_shift, min_protein_length
             )
+            # An active repair still needs trustworthy splice calls to build
+            # on, exactly like the invalid-ORF repair path below -- but a
+            # non-canonical intron only blocks the *switch*, not the
+            # informational weak_kozak_support flag, since flagging never
+            # changes gene structure.
+            blocked_by_noncanonical_introns = require_canonical and (
+                has_noncanonical_introns(transcript, chrom)
+            )
             if (
-                alt is not None
+                not blocked_by_noncanonical_introns
+                and alt is not None
                 and original_score is not None
                 and alt[2] > original_score + kozak_margin
             ):
@@ -635,18 +697,7 @@ def repair_transcript(
         )
 
     # Introns must be trustworthy before an ORF is built on top of them.
-    noncanonical = 0
-    for intron_start, intron_end in transcript.introns():
-        if intron_end < intron_start:
-            noncanonical += 1
-            continue
-        donor = chrom[intron_start - 1 : intron_start + 1].upper()
-        acceptor = chrom[intron_end - 2 : intron_end].upper()
-        if transcript.strand == "-":
-            donor, acceptor = revcomp(acceptor), revcomp(donor)
-        if (donor, acceptor) not in CANONICAL_SPLICE_PAIRS:
-            noncanonical += 1
-    if noncanonical and require_canonical:
+    if has_noncanonical_introns(transcript, chrom) and require_canonical:
         return (
             Result(
                 "partial",
@@ -712,7 +763,7 @@ def fix_orf(
     fix_weak_starts: bool = True,
     weak_start_threshold: int = 9,
     kozak_margin: float = 0.5,
-    weak_kozak_threshold: float = 2.0,
+    weak_kozak_threshold: float = 5.0,
 ) -> Counter:
     logger.info(f"Reading GFF {input_gff}")
     header, records = read_gff(input_gff)
@@ -853,7 +904,10 @@ def fix_orf(
     )
     issues = {k[6:]: v for k, v in stats.items() if k.startswith("issue:")}
     if issues:
-        logger.info("  unrepaired, by reason:")
+        # Not all issues mean "unrepaired": weak_start_kozak is a repair
+        # that happened (status=repaired) but is still worth surfacing here;
+        # the others (noncanonical_intron, ambiguous_bases, ...) are not.
+        logger.info("  by issue:")
         for reason, count in sorted(issues.items(), key=lambda kv: -kv[1]):
             logger.info(f"    {reason:24s} {count:8d}")
     if shift_hist:
@@ -924,7 +978,7 @@ def main() -> None:
     parser.add_argument(
         "--weak-kozak-threshold",
         type=float,
-        default=2.0,
+        default=5.0,
         help="Kozak log2-odds score below which even the best candidate "
         "start is flagged (orf_issue=weak_kozak_support) rather than kept "
         "silently.",

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -611,37 +611,10 @@ def repair_transcript(
     weak_kozak_threshold: float,
 ) -> tuple[Result, list[Record] | None]:
     """Evaluate and, if needed and possible, repair one transcript's CDS."""
-    cds_records = [r for r in transcript.children if r.type == CDS]
-    if not cds_records:
-        return Result("skipped", "no_cds"), None
-
-    transcript.build_exons()
-    if transcript.length == 0:
-        return Result("skipped", "no_exons"), None
-
-    seq = transcript.spliced_sequence(chrom)
-    if len(seq) != transcript.length:
-        return Result("skipped", "sequence_length_mismatch"), None
-
-    # Locate the predicted CDS in transcript coordinates.
-    coding_first = min(r.start for r in cds_records)
-    coding_last = max(r.end for r in cds_records)
-    if transcript.strand == "+":
-        begin = transcript.genomic_to_transcript(coding_first)
-        stop_inclusive = transcript.genomic_to_transcript(coding_last)
-    else:
-        begin = transcript.genomic_to_transcript(coding_last)
-        stop_inclusive = transcript.genomic_to_transcript(coding_first)
-    if begin is None or stop_inclusive is None:
-        return Result("skipped", "cds_outside_exons"), None
-    stop = stop_inclusive + 1
-
-    cds_length = sum(r.end - r.start + 1 for r in cds_records)
-    if stop - begin != cds_length:
-        # The predicted CDS is not contiguous within the spliced transcript,
-        # which means UTR was called between two CDS blocks.  Repairing that
-        # would require changing the model's own feature layout.
-        return Result("partial", "discontiguous_cds"), None
+    located = locate_cds(transcript, chrom)
+    if isinstance(located, Result):
+        return located, None
+    seq, begin, stop = located
 
     missing_start = seq[begin : begin + 3] != START_CODON
     missing_stop = seq[stop - 3 : stop] not in STOP_CODONS
@@ -759,19 +732,21 @@ def iter_fasta(path: str):
             yield seqid, "".join(chunks)
 
 
-def locate_cds(transcript: Transcript, chrom: str) -> tuple[str, int, int] | None:
+def locate_cds(transcript: Transcript, chrom: str) -> tuple[str, int, int] | Result:
     """(spliced_seq, begin, stop) for a transcript's predicted CDS in transcript
-    coordinates, or None if it can't be located. stop is exclusive. Shared
-    setup between repair_transcript and calibrate_kozak_margin."""
+    coordinates, or a Result describing why it couldn't be located. stop is
+    exclusive. Shared setup between repair_transcript and
+    calibrate_kozak_margin -- the latter only cares whether this succeeded,
+    not why it failed, and skips the transcript on any Result return."""
     cds_records = [r for r in transcript.children if r.type == CDS]
     if not cds_records:
-        return None
+        return Result("skipped", "no_cds")
     transcript.build_exons()
     if transcript.length == 0:
-        return None
+        return Result("skipped", "no_exons")
     seq = transcript.spliced_sequence(chrom)
     if len(seq) != transcript.length:
-        return None
+        return Result("skipped", "sequence_length_mismatch")
     coding_first = min(r.start for r in cds_records)
     coding_last = max(r.end for r in cds_records)
     if transcript.strand == "+":
@@ -781,11 +756,14 @@ def locate_cds(transcript: Transcript, chrom: str) -> tuple[str, int, int] | Non
         begin = transcript.genomic_to_transcript(coding_last)
         stop_inclusive = transcript.genomic_to_transcript(coding_first)
     if begin is None or stop_inclusive is None:
-        return None
+        return Result("skipped", "cds_outside_exons")
     stop = stop_inclusive + 1
     cds_length = sum(r.end - r.start + 1 for r in cds_records)
     if stop - begin != cds_length:
-        return None
+        # The predicted CDS is not contiguous within the spliced transcript,
+        # which means UTR was called between two CDS blocks.  Repairing that
+        # would require changing the model's own feature layout.
+        return Result("partial", "discontiguous_cds")
     return seq, begin, stop
 
 
@@ -850,7 +828,7 @@ def calibrate_kozak_margin(
             continue
         for transcript in by_seqid[seqid]:
             located = locate_cds(transcript, chrom)
-            if located is None:
+            if isinstance(located, Result):
                 continue
             seq, begin, stop = located
             if "N" in seq[begin:stop]:

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -34,7 +34,15 @@ The repair is deliberately constrained so that it cannot invent gene structure:
     5'UTR on that exon) is shorter than --weak-start-threshold, alternative
     start codons within the same already-predicted exonic sequence are
     considered and the one with the strongest Kozak-context support is
-    preferred, provided it beats the original by --kozak-margin. Candidates
+    preferred, provided it beats the original by --kozak-margin. --kozak-margin
+    is a floor, not a fixed value: by default it is raised per genome by
+    calibrate_kozak_margin, which checks the same switch logic against this
+    genome's own unambiguous start codons and raises the margin only as far
+    as needed to keep the measured rate of switching away from a known-correct
+    start at or below 2% (see calibrate_kozak_margin's docstring for the
+    cross-species numbers behind that -- one held-out species had a
+    quiet-but-real 8-9% false-positive rate at the fixed default that this
+    catches). Disable with --no-calibrate-kozak-margin. Candidates
     are restricted to the original start's reading frame *and* to those
     whose own forced stop is the original stop codon unchanged, so a switch
     can only move the TIS -- it can never change the stop codon or the
@@ -751,6 +759,141 @@ def iter_fasta(path: str):
             yield seqid, "".join(chunks)
 
 
+def locate_cds(transcript: Transcript, chrom: str) -> tuple[str, int, int] | None:
+    """(spliced_seq, begin, stop) for a transcript's predicted CDS in transcript
+    coordinates, or None if it can't be located. stop is exclusive. Shared
+    setup between repair_transcript and calibrate_kozak_margin."""
+    cds_records = [r for r in transcript.children if r.type == CDS]
+    if not cds_records:
+        return None
+    transcript.build_exons()
+    if transcript.length == 0:
+        return None
+    seq = transcript.spliced_sequence(chrom)
+    if len(seq) != transcript.length:
+        return None
+    coding_first = min(r.start for r in cds_records)
+    coding_last = max(r.end for r in cds_records)
+    if transcript.strand == "+":
+        begin = transcript.genomic_to_transcript(coding_first)
+        stop_inclusive = transcript.genomic_to_transcript(coding_last)
+    else:
+        begin = transcript.genomic_to_transcript(coding_last)
+        stop_inclusive = transcript.genomic_to_transcript(coding_first)
+    if begin is None or stop_inclusive is None:
+        return None
+    stop = stop_inclusive + 1
+    cds_length = sum(r.end - r.start + 1 for r in cds_records)
+    if stop - begin != cds_length:
+        return None
+    return seq, begin, stop
+
+
+# Target false-positive rate for calibrate_kozak_margin: the fraction of a
+# genome's own already-correct start codons the calibrated margin is allowed
+# to risk switching away from. 2% was picked the same way exon_length
+# strictness and the Kozak margin/threshold defaults were: bracketed against
+# real cross-species validation, not guessed. See calibrate_kozak_margin.
+KOZAK_MARGIN_TARGET_FP_RATE = 0.02
+
+
+def calibrate_kozak_margin(
+    by_seqid: dict[str, list[Transcript]],
+    input_fasta: str,
+    max_shift: int,
+    min_protein_length: int,
+    weak_start_threshold: int,
+    default_margin: float,
+    min_confident: int = 200,
+) -> float:
+    """Pick --kozak-margin for this genome instead of trusting one fixed
+    value for every species.
+
+    A single cross-species Kozak PWM does not carry the same reliability
+    into every genome it is applied to -- the model's own weak-start
+    candidates are ambiguous by construction, so there is no direct way to
+    check the margin against them, but every genome already has thousands of
+    transcripts whose start is *not* ambiguous (first coding exon well clear
+    of weak_start_threshold, complete ORF, canonical introns). Those are
+    known-correct starts. Running the same find_best_start_by_kozak logic
+    against them, at the default margin, measures directly how often this
+    genome's Kozak scores would talk the rule into switching away from a
+    start already known to be right -- a per-genome reliability estimate
+    that needs no assumption about what a "universal" Kozak signal looks
+    like, and no borrowed cross-species data.
+
+    The margin is raised only as far as needed to keep that measured
+    false-positive rate at or below KOZAK_MARGIN_TARGET_FP_RATE (the
+    (1 - KOZAK_MARGIN_TARGET_FP_RATE) quantile of the score-gap distribution
+    over known-correct starts), never lowered below default_margin.
+
+    Cross-species validation (Othomaeum, Rcommunis, Cquinoa, Oeuropaea;
+    reference-annotated, held out from PWM fitting): at the fixed default
+    margin, aggregate precision on switches that actually changed TIS
+    correctness was 66.3% (63 correct / 32 wrong), but Cquinoa alone was
+    net negative (9 correct / 12 wrong) -- its own confident starts showed
+    an 8-9% false-positive rate against the default margin, far above the
+    other three species. Per-genome calibration raised Cquinoa's margin
+    enough to stop triggering wrong switches there (0/0) while leaving the
+    other three species' margins close to the default, moving aggregate
+    precision to 78.3% (18/23) with no species left net negative.
+
+    Falls back to default_margin if there are too few confident transcripts
+    (under 200) to calibrate against reliably -- e.g. a single small
+    scaffold processed on its own.
+    """
+    gaps: list[float] = []
+    n_confident = 0
+
+    for seqid, chrom in iter_fasta(input_fasta):
+        if seqid not in by_seqid:
+            continue
+        for transcript in by_seqid[seqid]:
+            located = locate_cds(transcript, chrom)
+            if located is None:
+                continue
+            seq, begin, stop = located
+            if "N" in seq[begin:stop]:
+                continue
+            if not is_complete_orf(seq, begin, stop, min_protein_length):
+                continue
+            if first_exon_length(transcript, begin, stop) < weak_start_threshold:
+                continue  # the ambiguous population itself -- must not leak into calibration
+            if has_noncanonical_introns(transcript, chrom):
+                continue
+            original_score = kozak_score(seq, begin)
+            if original_score is None:
+                continue
+            alt = find_best_start_by_kozak(
+                seq, begin, stop, max_shift, min_protein_length
+            )
+            n_confident += 1
+            if alt is not None:
+                gaps.append(alt[2] - original_score)
+
+    if n_confident < min_confident:
+        logger.warning(
+            f"Only {n_confident} confident in-genome start codons found; too few "
+            f"to calibrate --kozak-margin, keeping default {default_margin}"
+        )
+        return default_margin
+
+    gaps.sort()
+    n_would_switch = sum(1 for g in gaps if g > default_margin)
+    if gaps:
+        k = min(int(len(gaps) * (1 - KOZAK_MARGIN_TARGET_FP_RATE)), len(gaps) - 1)
+        calibrated = max(default_margin, gaps[k])
+    else:
+        calibrated = default_margin
+    logger.info(
+        f"Calibrated --kozak-margin {default_margin} -> {calibrated:.2f} from "
+        f"{n_confident} confident in-genome start codons ({n_would_switch}/"
+        f"{n_confident} = {100 * n_would_switch / n_confident:.2f}% would have "
+        f"been wrongly switched at the default margin)"
+    )
+    return calibrated
+
+
 def fix_orf(
     input_gff: str,
     input_fasta: str,
@@ -763,6 +906,7 @@ def fix_orf(
     weak_start_threshold: int = 9,
     kozak_margin: float = 3.0,
     weak_kozak_threshold: float = 5.0,
+    calibrate_margin: bool = True,
 ) -> Counter:
     logger.info(f"Reading GFF {input_gff}")
     header, records = read_gff(input_gff)
@@ -789,6 +933,16 @@ def fix_orf(
     by_seqid: dict[str, list[Transcript]] = defaultdict(list)
     for transcript in transcripts.values():
         by_seqid[transcript.seqid].append(transcript)
+
+    if fix_weak_starts and calibrate_margin:
+        kozak_margin = calibrate_kozak_margin(
+            by_seqid,
+            input_fasta,
+            max_shift,
+            min_protein_length,
+            weak_start_threshold,
+            kozak_margin,
+        )
 
     stats: Counter = Counter()
     shift_hist: Counter = Counter()
@@ -972,7 +1126,17 @@ def main() -> None:
         type=float,
         default=3.0,
         help="Minimum Kozak log2-odds advantage an alternative start codon "
-        "must have over the original to trigger a switch.",
+        "must have over the original to trigger a switch. Used as the floor "
+        "value calibrate_kozak_margin raises from per genome, unless "
+        "--no-calibrate-kozak-margin is set, in which case it is used as-is.",
+    )
+    parser.add_argument(
+        "--no-calibrate-kozak-margin",
+        dest="calibrate_margin",
+        action="store_false",
+        help="Use --kozak-margin as a fixed value for every genome instead of "
+        "raising it per genome from that genome's own confident (unambiguous) "
+        "start codons. On by default.",
     )
     parser.add_argument(
         "--weak-kozak-threshold",
@@ -1001,6 +1165,7 @@ def main() -> None:
         weak_start_threshold=args.weak_start_threshold,
         kozak_margin=args.kozak_margin,
         weak_kozak_threshold=args.weak_kozak_threshold,
+        calibrate_margin=args.calibrate_margin,
     )
 
 

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -536,6 +536,10 @@ def repair_transcript(
     max_shift: int,
     min_protein_length: int,
     require_canonical: bool,
+    fix_weak_starts: bool,
+    weak_start_threshold: int,
+    kozak_margin: float,
+    weak_kozak_threshold: float,
 ) -> tuple[Result, list[Record] | None]:
     """Evaluate and, if needed and possible, repair one transcript's CDS."""
     cds_records = [r for r in transcript.children if r.type == CDS]
@@ -575,6 +579,37 @@ def repair_transcript(
     ambiguous = "N" in seq[begin:stop]
 
     if not ambiguous and is_complete_orf(seq, begin, stop, min_protein_length):
+        if (
+            fix_weak_starts
+            and first_exon_length(transcript, begin, stop) < weak_start_threshold
+        ):
+            original_score = kozak_score(seq, begin)
+            alt = find_best_start_by_kozak(
+                seq, begin, stop, max_shift, min_protein_length
+            )
+            if (
+                alt is not None
+                and original_score is not None
+                and alt[2] > original_score + kozak_margin
+            ):
+                new_begin, new_stop, _ = alt
+                records = rebuild_children(
+                    transcript, new_begin, new_stop, transcript.children
+                )
+                return (
+                    Result(
+                        "repaired",
+                        issue="weak_start_kozak",
+                        shift5=new_begin - begin,
+                        shift3=new_stop - stop,
+                    ),
+                    records,
+                )
+            candidate_scores = [
+                s for s in (original_score, alt[2] if alt else None) if s is not None
+            ]
+            if candidate_scores and max(candidate_scores) < weak_kozak_threshold:
+                return Result("complete", issue="weak_kozak_support"), None
         return Result("complete"), None
 
     if "N" in seq:
@@ -665,6 +700,10 @@ def fix_orf(
     min_protein_length: int,
     require_canonical: bool,
     report_path: str | None,
+    fix_weak_starts: bool = True,
+    weak_start_threshold: int = 9,
+    kozak_margin: float = 1.0,
+    weak_kozak_threshold: float = 0.0,
 ) -> Counter:
     logger.info(f"Reading GFF {input_gff}")
     header, records = read_gff(input_gff)
@@ -710,6 +749,10 @@ def fix_orf(
                 max_shift=max_shift,
                 min_protein_length=min_protein_length,
                 require_canonical=require_canonical,
+                fix_weak_starts=fix_weak_starts,
+                weak_start_threshold=weak_start_threshold,
+                kozak_margin=kozak_margin,
+                weak_kozak_threshold=weak_kozak_threshold,
             )
             mrna_id = transcript.mrna.id or ""
             results[mrna_id] = result
@@ -849,6 +892,35 @@ def main() -> None:
         "Off by default: an ORF built on untrustworthy splice calls is not trustworthy.",
     )
     parser.add_argument(
+        "--no-fix-weak-starts",
+        dest="fix_weak_starts",
+        action="store_false",
+        help="Disable Kozak-context re-ranking of already-valid but "
+        "suspiciously short first exons. On by default.",
+    )
+    parser.add_argument(
+        "--weak-start-threshold",
+        type=int,
+        default=9,
+        help="First coding exon length (nt) below which alternative start "
+        "codons are considered, when --no-fix-weak-starts is not set.",
+    )
+    parser.add_argument(
+        "--kozak-margin",
+        type=float,
+        default=1.0,
+        help="Minimum Kozak log2-odds advantage an alternative start codon "
+        "must have over the original to trigger a switch.",
+    )
+    parser.add_argument(
+        "--weak-kozak-threshold",
+        type=float,
+        default=0.0,
+        help="Kozak log2-odds score below which even the best candidate "
+        "start is flagged (orf_issue=weak_kozak_support) rather than kept "
+        "silently.",
+    )
+    parser.add_argument(
         "--report",
         default=None,
         help="Optional TSV path for per-transcript status output",
@@ -863,6 +935,10 @@ def main() -> None:
         min_protein_length=args.min_protein_length,
         require_canonical=not args.allow_noncanonical_introns,
         report_path=args.report,
+        fix_weak_starts=args.fix_weak_starts,
+        weak_start_threshold=args.weak_start_threshold,
+        kozak_margin=args.kozak_margin,
+        weak_kozak_threshold=args.weak_kozak_threshold,
     )
 
 

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -26,6 +26,15 @@ The repair is deliberately constrained so that it cannot invent gene structure:
     (minimum total boundary movement), and movement is capped by --max-shift.
     Truncating a long CDS down to a short ORF is therefore rejected: it would
     require a large 3' shift.
+6.  Even when the predicted CDS is already a valid ORF, if its first exon
+    is shorter than --weak-start-threshold, alternative start codons within
+    the same already-predicted exonic sequence are considered and the one
+    with the strongest Kozak-context support is preferred, provided it
+    beats the original by --kozak-margin. This still only relabels
+    predicted exonic sequence (rule 2 still applies) -- it never invents
+    new gene structure. Transcripts whose best candidate is still weak
+    (--weak-kozak-threshold) are flagged (orf_issue=weak_kozak_support)
+    rather than forced. Disable with --no-fix-weak-starts.
 
 Transcripts that cannot be repaired under these rules are *not* forced into an
 ORF.  They are passed through unchanged and flagged (partial=true, orf_issue=…,
@@ -702,8 +711,8 @@ def fix_orf(
     report_path: str | None,
     fix_weak_starts: bool = True,
     weak_start_threshold: int = 9,
-    kozak_margin: float = 1.0,
-    weak_kozak_threshold: float = 0.0,
+    kozak_margin: float = 0.5,
+    weak_kozak_threshold: float = 2.0,
 ) -> Counter:
     logger.info(f"Reading GFF {input_gff}")
     header, records = read_gff(input_gff)
@@ -908,14 +917,14 @@ def main() -> None:
     parser.add_argument(
         "--kozak-margin",
         type=float,
-        default=1.0,
+        default=0.5,
         help="Minimum Kozak log2-odds advantage an alternative start codon "
         "must have over the original to trigger a switch.",
     )
     parser.add_argument(
         "--weak-kozak-threshold",
         type=float,
-        default=0.0,
+        default=2.0,
         help="Kozak log2-odds score below which even the best candidate "
         "start is flagged (orf_issue=weak_kozak_support) rather than kept "
         "silently.",

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -55,6 +55,59 @@ START_CODON = "ATG"
 # transcribed strand.  GT-AG and GC-AG are U2-type; AT-AC is U12-type.
 CANONICAL_SPLICE_PAIRS = frozenset((("GT", "AG"), ("GC", "AG"), ("AT", "AC")))
 
+# Log2-odds Kozak-context PWM: fit once, offline, from real confirmed start
+# codons pooled across multiple Phytozome plant species (see
+# docs/superpowers/specs/2026-08-15-fix-orf-weak-start-repair-design.md for
+# methodology). Deliberately excludes Oropetium thomaeum, the species used
+# to validate this whole change -- fitting and validating on the same
+# species would be circular. Window is [-KOZAK_WINDOW_UPSTREAM, ATG,
+# +KOZAK_WINDOW_DOWNSTREAM] in coding (5'->3') orientation, columns A/C/G/T.
+KOZAK_WINDOW_UPSTREAM = 6
+KOZAK_WINDOW_DOWNSTREAM = 6
+KOZAK_PWM_LOG_ODDS: tuple[tuple[float, float, float, float], ...] = (
+    (0.0136, -0.0756, 0.3939, -0.2537),
+    (-0.0890, 0.5300, -0.0483, -0.2820),
+    (0.3170, 0.0057, 0.2045, -0.5907),
+    (0.4690, -0.5523, 0.5644, -0.9349),
+    (0.2857, 0.7449, -0.6555, -0.7332),
+    (0.2614, 0.4346, 0.3240, -1.1425),
+    (1.6575, -19.6135, -19.6135, -20.4058),
+    (-20.4059, -19.6135, -19.6135, 1.6576),
+    (-20.4059, -19.6135, 2.4499, -20.4058),
+    (-0.4964, -0.9217, 1.5662, -1.2134),
+    (-0.0608, 0.9640, -0.0891, -0.9244),
+    (-0.4841, -0.3068, 0.8155, -0.0636),
+    (0.0288, -0.1188, 0.6590, -0.5329),
+    (-0.1478, 0.6393, 0.0373, -0.3954),
+    (-0.3735, 0.2646, 0.4629, -0.1626),
+)
+KOZAK_BACKGROUND: tuple[float, float, float, float] = (0.3170, 0.1830, 0.1830, 0.3170)
+
+# Consensus: AAAAAAATGGCGAAT  (positions -6..ATG..+6)
+# Fit from 438262 confirmed start codons pooled across 11 species: Athaliana,
+# Bstricta, Crubella, Esalsugineum, Fvesca, Csativus, Cclementina,
+# Mtruncatula, Ljaponicus, Dcarota, Osativa.
+
+
+def kozak_score(seq: str, atg_offset: int) -> float | None:
+    """Log2-odds Kozak-context score for the ATG at transcript offset atg_offset.
+
+    None if the window falls outside seq, or contains a base other than
+    A/C/G/T (an assembly gap in the window makes the score meaningless).
+    """
+    lo = atg_offset - KOZAK_WINDOW_UPSTREAM
+    hi = atg_offset + 3 + KOZAK_WINDOW_DOWNSTREAM
+    if lo < 0 or hi > len(seq):
+        return None
+    window = seq[lo:hi]
+    score = 0.0
+    for i, base in enumerate(window):
+        if base not in "ACGT":
+            return None
+        score += KOZAK_PWM_LOG_ODDS[i]["ACGT".index(base)]
+    return score
+
+
 CDS = "CDS"
 FIVE_PRIME_UTR = "five_prime_UTR"
 THREE_PRIME_UTR = "three_prime_UTR"

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -408,6 +408,65 @@ def find_best_orf(
     return best
 
 
+def first_exon_length(transcript: Transcript, begin: int, stop: int) -> int:
+    """Length, in transcript coordinates, of the CDS's first coding exon.
+
+    The CDS is already known contiguous within the spliced transcript (the
+    caller has already ruled out ``discontiguous_cds``), so the first splice
+    junction after ``begin`` -- the smallest exon offset strictly greater
+    than ``begin`` -- caps the first coding exon, or ``stop`` does if
+    ``begin`` falls in the CDS's last exon.
+    """
+    later_offsets = [o for o in transcript.exon_offsets if o > begin]
+    first_exon_end = min(later_offsets) if later_offsets else stop
+    return min(first_exon_end, stop) - begin
+
+
+def find_best_start_by_kozak(
+    seq: str,
+    cds_begin: int,
+    cds_stop: int,
+    max_shift: int,
+    min_protein_length: int,
+) -> tuple[int, int, float] | None:
+    """Best-Kozak-scoring valid ORF within max_shift of (cds_begin, cds_stop).
+
+    Same candidate space as find_best_orf -- every in-frame ATG within the
+    window, each with its forced downstream in-frame stop -- but ranked by
+    kozak_score() instead of boundary movement. Candidates whose Kozak
+    window falls outside the sequence (kozak_score returns None) are
+    skipped: there is nothing to compare.
+
+    Returns
+    -------
+    tuple[int, int, float] | None
+        (begin, stop, kozak_score) for the winner, or None if no valid
+        candidate in the window has a computable Kozak score.
+    """
+    next_stop = build_next_in_frame_stop(seq)
+    lo = max(0, cds_begin - max_shift)
+    hi = min(len(seq), cds_begin + max_shift + 1)
+
+    best: tuple[int, int, float] | None = None
+    for begin in range(lo, hi):
+        if seq[begin : begin + 3] != START_CODON:
+            continue
+        stop_offset = next_stop[begin]
+        if stop_offset < 0:
+            continue
+        stop = stop_offset + 3
+        if stop - begin < 3 * (min_protein_length + 1):
+            continue
+        if abs(stop - cds_stop) > max_shift:
+            continue
+        score = kozak_score(seq, begin)
+        if score is None:
+            continue
+        if best is None or score > best[2]:
+            best = (begin, stop, score)
+    return best
+
+
 # -------------------------------------------------------------------------------------------------
 # Repair
 # -------------------------------------------------------------------------------------------------

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -73,12 +73,11 @@ START_CODON = "ATG"
 CANONICAL_SPLICE_PAIRS = frozenset((("GT", "AG"), ("GC", "AG"), ("AT", "AC")))
 
 # Log2-odds Kozak-context PWM: fit once, offline, from real confirmed start
-# codons pooled across multiple Phytozome plant species (see
-# docs/superpowers/specs/2026-08-15-fix-orf-weak-start-repair-design.md for
-# methodology). Deliberately excludes Oropetium thomaeum, the species used
-# to validate this whole change -- fitting and validating on the same
-# species would be circular. Window is [-KOZAK_WINDOW_UPSTREAM, ATG,
-# +KOZAK_WINDOW_DOWNSTREAM] in coding (5'->3') orientation, columns A/C/G/T.
+# codons pooled across multiple Phytozome plant species. Deliberately
+# excludes Oropetium thomaeum, the species used to validate this whole
+# change -- fitting and validating on the same species would be circular.
+# Window is [-KOZAK_WINDOW_UPSTREAM, ATG, +KOZAK_WINDOW_DOWNSTREAM] in
+# coding (5'->3') orientation, columns A/C/G/T.
 KOZAK_WINDOW_UPSTREAM = 6
 KOZAK_WINDOW_DOWNSTREAM = 6
 KOZAK_PWM_LOG_ODDS: tuple[tuple[float, float, float, float], ...] = (

--- a/scripts/fix_orf.py
+++ b/scripts/fix_orf.py
@@ -762,7 +762,7 @@ def fix_orf(
     report_path: str | None,
     fix_weak_starts: bool = True,
     weak_start_threshold: int = 9,
-    kozak_margin: float = 0.5,
+    kozak_margin: float = 3.0,
     weak_kozak_threshold: float = 5.0,
 ) -> Counter:
     logger.info(f"Reading GFF {input_gff}")
@@ -971,7 +971,7 @@ def main() -> None:
     parser.add_argument(
         "--kozak-margin",
         type=float,
-        default=0.5,
+        default=3.0,
         help="Minimum Kozak log2-odds advantage an alternative start codon "
         "must have over the original to trigger a switch.",
     )

--- a/scripts/install_release.sh
+++ b/scripts/install_release.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Usage:
 #   bash scripts/install_release.sh
 # Optional env vars:
-#   GENECAD_VERSION=0.4.0
+#   GENECAD_VERSION=0.4.2
 #   PYTORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu128
 
-GENECAD_VERSION="${GENECAD_VERSION:-0.4.0}"
+GENECAD_VERSION="${GENECAD_VERSION:-0.4.2}"
 PYTORCH_CUDA_INDEX="${PYTORCH_CUDA_INDEX:-https://download.pytorch.org/whl/cu128}"
 WHEEL_URL="https://github.com/plantcad/genecad/releases/download/v${GENECAD_VERSION}/genecad-${GENECAD_VERSION}-py3-none-any.whl"
 

--- a/scripts/predict_and_visualize.py
+++ b/scripts/predict_and_visualize.py
@@ -409,6 +409,7 @@ def step_detect_intervals(
     decoding_methods: str,
     domain: str,
     script_dir: str,
+    input_fasta: str,
 ) -> None:
     if os.path.exists(intervals_zarr):
         logger.info("[3/3] intervals.zarr already exists — skipping interval detection")
@@ -429,6 +430,8 @@ def step_detect_intervals(
             "yes",
             "--domain",
             domain,
+            "--input-fasta",
+            input_fasta,
         ]
     )
 
@@ -576,6 +579,7 @@ def main() -> None:
         decoding_methods=args.decoding_methods,
         domain=args.domain,
         script_dir=SCRIPT_DIR,
+        input_fasta=args.fasta,
     )
 
     # --- Step 4: Load results and visualize ---

--- a/src/frame_crf.py
+++ b/src/frame_crf.py
@@ -81,7 +81,7 @@ Known limitations
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import NamedTuple
 
 import numpy as np
@@ -250,38 +250,6 @@ STRUCTURAL_MIN_INTRON_LENGTH = 5
 DEFAULT_MIN_INTRON_LENGTH = 20
 
 
-def intron_chain_parts(
-    min_intron_length: int,
-    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
-) -> dict[str, list[tuple[str, int]]]:
-    """Per-group (suffix, base constraint) lists for the states of one intron.
-
-    Keyed by :attr:`SpliceMotifGroup.name`. Within a group's chain, ``b1..bk``
-    are mandatory body positions that impose the minimum length; the looping
-    ``body`` state that follows is what actually absorbs intron length. Groups
-    never merge -- each gets its own donor, body and acceptor states -- so an
-    intron entered through one group's donor can only leave through that same
-    group's acceptor.
-    """
-    if min_intron_length < STRUCTURAL_MIN_INTRON_LENGTH:
-        raise ValueError(
-            f"min_intron_length must be at least {STRUCTURAL_MIN_INTRON_LENGTH}; "
-            f"got {min_intron_length}"
-        )
-    mandatory = min_intron_length - STRUCTURAL_MIN_INTRON_LENGTH
-    body_parts = [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)] + [
-        ("body", MASK_ANY)
-    ]
-    return {
-        group.name: (
-            [("d1", group.donor_masks[0]), ("d2", group.donor_masks[1])]
-            + body_parts
-            + [("a1", group.acceptor_masks[0]), ("a2", group.acceptor_masks[1])]
-        )
-        for group in splice_motif_groups
-    }
-
-
 def intron_state(intron_class: str, group_name: str, part: str) -> str:
     return f"intron_{intron_class}_{group_name}_{part}"
 
@@ -379,43 +347,6 @@ DEFAULT_MIN_CODING_RUN_LENGTH = 9
 DEFAULT_EXON_LENGTH_STRICTNESS = 16.0
 
 
-def exon_lock_states(min_coding_run_length: int) -> list[State]:
-    """States that force at least ``min_coding_run_length`` bases of coding sequence
-    before intron entry (or the terminal stop) becomes reachable again,
-    mirroring :data:`CDS_PHASE_STATES` at each remaining-length level.
-
-    Level ``L`` means "L more bases must be read before the real, unlocked
-    CDS states -- which do offer intron entry -- become reachable". Every
-    transition consumes one base and steps down exactly one level, so no path
-    can reach an intron or the stop codon before the minimum has elapsed.
-    Level 1 is the last locked level; its own transitions land directly on
-    the real states, so only ``min_coding_run_length - 1`` levels are ever
-    materialised, and none at all once ``min_coding_run_length <= 1``.
-    """
-    return [
-        State(f"lock{level}_{suffix}", CDS, mask)
-        for level in range(min_coding_run_length - 1, 0, -1)
-        for suffix, mask in CDS_PHASE_STATES
-    ]
-
-
-def exon_lock_destination(
-    suffix: str, min_coding_run_length: int, already_consumed: int
-) -> str:
-    """Name of the state to land in for codon-phase ``suffix`` (e.g.
-    ``"p0_t"``), given that ``already_consumed`` bases of the current exon
-    have already been read.
-
-    Returns a locked state if more coding sequence must still be forced
-    before intron entry is legal again, or the real (unlocked) state directly
-    once ``already_consumed`` plus this base already meets the minimum.
-    """
-    remaining = min_coding_run_length - already_consumed - 1
-    if remaining <= 0:
-        return f"cds_{suffix}"
-    return f"lock{remaining}_{suffix}"
-
-
 def exon_length_penalty(
     length: int, min_coding_run_length: int, exon_length_strictness: float
 ) -> float:
@@ -432,410 +363,434 @@ def exon_length_penalty(
     return (length / min_coding_run_length) ** exon_length_strictness
 
 
-def locked_destination(
-    base_state: str, min_coding_run_length: int, already_consumed: int
-) -> str:
-    """Single-track analogue of :func:`exon_lock_destination`, for lock chains
-    that have no codon phase to track (5' UTR) or whose phase is fixed (the
-    start codon).
+@dataclass(frozen=True)
+class FrameStateGraph:
+    """The expanded Viterbi state graph for one frame-aware decoding configuration.
 
-    Returns ``base_state`` once ``already_consumed`` plus this base already
-    meets ``min_coding_run_length``, otherwise ``f"{base_state}_lock{N}"``.
+    Owns the five values that determine both the state space and the edge
+    weights built from a transition matrix: ``min_intron_length``,
+    ``splice_motif_groups``, ``min_coding_run_length``,
+    ``exon_length_strictness``, and ``include_utr_in_coding_run``. See the
+    matching ``DEFAULT_*`` module constants above for the reasoning behind
+    each default. Set once at construction and read everywhere internally,
+    so there is no call path that can build states and edges from
+    mismatched values.
+
+    ``states`` is built eagerly in ``__post_init__``. ``build_edges()``
+    still needs a transition matrix argument, since edges also depend on
+    data that varies per decode (the matrix), not just on this
+    configuration. ``decode()`` does both, plus the Viterbi pass itself,
+    and is the main entry point for reusing one graph across multiple
+    decodes; :func:`frame_aware_decode` is a convenience wrapper for a
+    one-off decode.
     """
-    remaining = min_coding_run_length - already_consumed - 1
-    if remaining <= 0:
-        return base_state
-    return f"{base_state}_lock{remaining}"
 
+    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH
+    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS
+    min_coding_run_length: int = DEFAULT_MIN_CODING_RUN_LENGTH
+    exon_length_strictness: float = DEFAULT_EXON_LENGTH_STRICTNESS
+    include_utr_in_coding_run: bool = True
 
-def utr5_lock_states(min_coding_run_length: int) -> list[State]:
-    """States that carry a running count of 5' UTR bases consumed so far,
-    used by ``include_utr_in_coding_run`` to let a long 5' UTR satisfy
-    ``min_coding_run_length`` on its own, so a short first coding run isn't
-    penalized just because the exon's UTR portion isn't counted.
+    states: list[State] = field(init=False)
+    state_feature: np.ndarray = field(init=False)
+    state_mask: np.ndarray = field(init=False)
+    _state_index: dict[str, int] = field(init=False)
 
-    Mirrors :func:`exon_lock_states`, but with a single untyped state per
-    level (5' UTR carries no codon phase) and continuing into the start codon
-    via :func:`start_lock_states` rather than resetting at the start codon.
-    """
-    return [
-        State(f"utr5_lock{level}", U5, MASK_ANY)
-        for level in range(min_coding_run_length - 1, 0, -1)
-    ]
-
-
-def start_lock_states(min_coding_run_length: int) -> list[State]:
-    """Locked variants of the start codon (A/T/G) used by
-    ``include_utr_in_coding_run`` to carry the running UTR+CDS base count
-    from :func:`utr5_lock_states` across the mandatory ATG, which otherwise
-    has no branching point at which to track it.
-
-    Each position can only be reached once at least that many bases
-    (1 for the A, 2 for the T, 3 for the G) have already been consumed, so
-    the reachable level range narrows by one at each position; generating
-    the full ``min_coding_run_length - 1`` range at every position would
-    otherwise leave unreachable states that fail the graph-connectivity check.
-    """
-    specs = [
-        ("start_a", MASK_IS_A, 1),
-        ("start_t", MASK_IS_T, 2),
-        ("start_g", MASK_IS_G, 3),
-    ]
-    return [
-        State(f"{name}_lock{level}", CDS, mask)
-        for name, mask, min_consumed in specs
-        for level in range(min_coding_run_length - min_consumed, 0, -1)
-    ]
-
-
-def build_states(
-    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
-    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
-    min_coding_run_length: int = DEFAULT_MIN_CODING_RUN_LENGTH,
-    include_utr_in_coding_run: bool = True,
-) -> list[State]:
-    states = list(CORE_STATES)
-    chain_parts = intron_chain_parts(min_intron_length, splice_motif_groups)
-    for intron_class, _ in INTRON_CLASSES:
-        for group_name, parts in chain_parts.items():
-            for part, mask in parts:
-                states.append(
-                    State(intron_state(intron_class, group_name, part), IN, mask)
-                )
-    states.extend(exon_lock_states(min_coding_run_length))
-    if include_utr_in_coding_run:
-        states.extend(utr5_lock_states(min_coding_run_length))
-        states.extend(start_lock_states(min_coding_run_length))
-    return states
-
-
-MIN_INTRON_LENGTH = DEFAULT_MIN_INTRON_LENGTH
-MIN_CODING_RUN_LENGTH = DEFAULT_MIN_CODING_RUN_LENGTH
-STATES: list[State] = build_states()
-STATE_INDEX = {state.name: i for i, state in enumerate(STATES)}
-N_STATES = len(STATES)
-
-
-def build_edges(
-    feature_probs: np.ndarray,
-    min_intron_length: int = DEFAULT_MIN_INTRON_LENGTH,
-    splice_motif_groups: tuple[SpliceMotifGroup, ...] = DEFAULT_SPLICE_MOTIF_GROUPS,
-    min_coding_run_length: int = DEFAULT_MIN_CODING_RUN_LENGTH,
-    exon_length_strictness: float = DEFAULT_EXON_LENGTH_STRICTNESS,
-    include_utr_in_coding_run: bool = True,
-) -> list[tuple[int, int, float]]:
-    """Expand the 5x5 feature transition matrix into the frame-aware state graph.
-
-    Returns a list of ``(source, destination, probability)`` edges, indexed
-    against ``build_states(min_intron_length, min_coding_run_length=min_coding_run_length,
-    include_utr_in_coding_run=include_utr_in_coding_run)``.
-
-    Weights are taken directly from the feature matrix.  Where several expanded
-    successors share a feature *and* are mutually exclusive under their base
-    constraints -- for instance ``cds_p0_t`` and ``cds_p0_x`` -- each receives
-    the full feature weight rather than a share of it, because which one applies
-    is determined by the sequence, not by chance.  :func:`validate_edges` checks
-    that this never lets the feasible weight out of a state exceed 1.
-
-    include_utr_in_coding_run
-        When set, ``min_coding_run_length`` is measured over the
-        5' UTR plus the coding run rather than the coding run alone, so a long
-        UTR can by itself satisfy the minimum and exempt a short first coding
-        run from the penalty -- see ``utr5_lock_states``/``start_lock_states``.
-        Only the start side is covered; a symmetric fix for the stop/3' UTR
-        side is not implemented. On by default; pass False to fall back to the
-        coding-run-only behavior.
-    """
-    p = np.asarray(feature_probs, dtype=float)
-    if p.shape != (N_FEATURES, N_FEATURES):
-        raise ValueError(f"Expected a {N_FEATURES}x{N_FEATURES} matrix; got {p.shape}")
-
-    chain_parts = intron_chain_parts(min_intron_length, splice_motif_groups)
-    s = {
-        state.name: i
-        for i, state in enumerate(
-            build_states(
-                min_intron_length,
-                splice_motif_groups,
-                min_coding_run_length,
-                include_utr_in_coding_run,
+    def __post_init__(self) -> None:
+        if self.min_intron_length < STRUCTURAL_MIN_INTRON_LENGTH:
+            raise ValueError(
+                f"min_intron_length must be at least {STRUCTURAL_MIN_INTRON_LENGTH}; "
+                f"got {self.min_intron_length}"
             )
+        states = self._build_states()
+        object.__setattr__(self, "states", states)
+        object.__setattr__(
+            self,
+            "state_feature",
+            np.array([state.feature for state in states], dtype=np.int64),
         )
-    }
-    edges: list[tuple[int, int, float]] = []
-
-    def add(source: str, destination: str, weight: float) -> None:
-        if weight > 0:
-            edges.append((s[source], s[destination], float(weight)))
-
-    cds_cont, cds_intron, cds_end = p[CDS][CDS], p[CDS][IN], p[CDS][U3]
-    utr5_cont, utr5_intron, utr5_end = p[U5][U5], p[U5][IN], p[U5][CDS]
-    intron_stay = p[IN][IN]
-    intron_exit = 1.0 - intron_stay
-
-    # -- intergenic and 5' UTR ------------------------------------------------
-    add("intergenic", "intergenic", p[IG][IG])
-    if include_utr_in_coding_run:
-        add(
-            "intergenic",
-            locked_destination("utr5", min_coding_run_length, 0),
-            p[IG][U5],
+        object.__setattr__(
+            self,
+            "state_mask",
+            np.array([state.mask for state in states], dtype=np.int64),
         )
-    else:
-        add("intergenic", "utr5", p[IG][U5])
+        object.__setattr__(
+            self, "_state_index", {state.name: i for i, state in enumerate(states)}
+        )
 
-    def enter_intron(source: str, intron_class: str, weight: float) -> None:
-        # Each configured motif group's donor mask is mutually exclusive with
-        # every other group's (G-first vs A-first), so -- as with cds_p0_t /
-        # cds_p0_x above -- each gets the full weight rather than a share of
-        # it; only one can ever be feasible for a given base.
-        for group in splice_motif_groups:
-            add(source, intron_state(intron_class, group.name, "d1"), weight)
+    # -- state construction ---------------------------------------------
 
-    add("utr5", "utr5", utr5_cont)
-    enter_intron("utr5", "utr5", utr5_intron)
-    add("utr5", "start_a", utr5_end)
+    def _intron_chain_parts(self) -> dict[str, list[tuple[str, int]]]:
+        """Per-group (suffix, base constraint) lists for the states of one intron.
 
-    if include_utr_in_coding_run:
-        # Carries the running UTR+CDS base count from utr5_lock_states across
-        # the 5' UTR, so a long UTR can satisfy min_coding_run_length on its
-        # own -- see locked_destination/utr5_lock_states/start_lock_states.
-        for level in range(min_coding_run_length - 1, 0, -1):
-            consumed = min_coding_run_length - level
-            source = f"utr5_lock{level}"
-            add(
-                source,
-                locked_destination("utr5", min_coding_run_length, consumed),
-                utr5_cont,
-            )
-            add(
-                source,
-                locked_destination("start_a", min_coding_run_length, consumed),
-                utr5_end,
-            )
-            penalty = exon_length_penalty(
-                consumed, min_coding_run_length, exon_length_strictness
-            )
-            enter_intron(source, "utr5", utr5_intron * penalty)
-
-    # -- start codon ----------------------------------------------------------
-    add("start_a", "start_t", 1.0)
-    add("start_t", "start_g", 1.0)
-
-    def leave_codon_boundary(source: str) -> None:
-        """Successors of a CDS base that completes a codon.
-
-        The next base either opens an intron, continues the coding sequence, or
-        begins the terminal stop codon.  Reaching the 3' UTR is only possible
-        through that stop codon, so the feature matrix's CDS -> 3' UTR mass is
-        what drives entry into it.
+        See the old module-level ``intron_chain_parts`` docstring (removed)
+        for the full explanation: keyed by :attr:`SpliceMotifGroup.name`,
+        ``b1..bk`` are mandatory body positions imposing the minimum
+        length, and groups never merge.
         """
-        enter_intron(source, "p2", cds_intron)
-        add(source, "cds_p0_t", cds_cont)
-        add(source, "cds_p0_x", cds_cont)
-        add(source, "stop_t", cds_end)
-
-    # The start codon is 3 bases. Escaping straight from here into an intron
-    # gives a 3-base first exon, penalized the same way the lock chain
-    # penalizes any other short exon (full weight once min_coding_run_length <= 3,
-    # since 3 bases already meets it). The "continue coding" edges are routed
-    # through the lock chain instead of the real cds_p0_t/cds_p0_x, so that
-    # only *further* intron entry is deferred until the minimum is met.
-    # "start_g" -> "stop_t" is left alone either way: a start codon
-    # immediately followed by a stop isn't an exon split by an intron, so
-    # min_coding_run_length has no opinion on it.
-    add("start_g", "stop_t", cds_end)
-    if include_utr_in_coding_run:
-        # This plain (unlocked) start_g is only reachable once the 5' UTR
-        # alone already met min_coding_run_length (see the utr5_lock chain
-        # above), so the whole exon-length requirement is already satisfied
-        # here regardless of how little coding sequence follows -- no lock
-        # chain, no penalty, same as any other already-unlocked CDS state.
-        # The still-locked case is handled by the start_*_lock chain below.
-        add("start_g", "cds_p0_t", cds_cont)
-        add("start_g", "cds_p0_x", cds_cont)
-        enter_intron("start_g", "p2", cds_intron)
-
-        for level in range(min_coding_run_length - 1, 0, -1):
-            consumed = min_coding_run_length - level
-            add(
-                f"start_a_lock{level}",
-                locked_destination("start_t", min_coding_run_length, consumed),
-                1.0,
+        mandatory = self.min_intron_length - STRUCTURAL_MIN_INTRON_LENGTH
+        body_parts = [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)] + [
+            ("body", MASK_ANY)
+        ]
+        return {
+            group.name: (
+                [("d1", group.donor_masks[0]), ("d2", group.donor_masks[1])]
+                + body_parts
+                + [("a1", group.acceptor_masks[0]), ("a2", group.acceptor_masks[1])]
             )
-        for level in range(min_coding_run_length - 2, 0, -1):
-            consumed = min_coding_run_length - level
-            add(
-                f"start_t_lock{level}",
-                locked_destination("start_g", min_coding_run_length, consumed),
-                1.0,
+            for group in self.splice_motif_groups
+        }
+
+    def _exon_lock_states(self) -> list[State]:
+        return [
+            State(f"lock{level}_{suffix}", CDS, mask)
+            for level in range(self.min_coding_run_length - 1, 0, -1)
+            for suffix, mask in CDS_PHASE_STATES
+        ]
+
+    def _exon_lock_destination(self, suffix: str, already_consumed: int) -> str:
+        remaining = self.min_coding_run_length - already_consumed - 1
+        if remaining <= 0:
+            return f"cds_{suffix}"
+        return f"lock{remaining}_{suffix}"
+
+    def _locked_destination(self, base_state: str, already_consumed: int) -> str:
+        remaining = self.min_coding_run_length - already_consumed - 1
+        if remaining <= 0:
+            return base_state
+        return f"{base_state}_lock{remaining}"
+
+    def _utr5_lock_states(self) -> list[State]:
+        return [
+            State(f"utr5_lock{level}", U5, MASK_ANY)
+            for level in range(self.min_coding_run_length - 1, 0, -1)
+        ]
+
+    def _start_lock_states(self) -> list[State]:
+        specs = [
+            ("start_a", MASK_IS_A, 1),
+            ("start_t", MASK_IS_T, 2),
+            ("start_g", MASK_IS_G, 3),
+        ]
+        return [
+            State(f"{name}_lock{level}", CDS, mask)
+            for name, mask, min_consumed in specs
+            for level in range(self.min_coding_run_length - min_consumed, 0, -1)
+        ]
+
+    def _build_states(self) -> list[State]:
+        states = list(CORE_STATES)
+        chain_parts = self._intron_chain_parts()
+        for intron_class, _ in INTRON_CLASSES:
+            for group_name, parts in chain_parts.items():
+                for part, mask in parts:
+                    states.append(
+                        State(intron_state(intron_class, group_name, part), IN, mask)
+                    )
+        states.extend(self._exon_lock_states())
+        if self.include_utr_in_coding_run:
+            states.extend(self._utr5_lock_states())
+            states.extend(self._start_lock_states())
+        return states
+
+    # -- edges -------------------------------------------------------------
+
+    def build_edges(
+        self, feature_transition: np.ndarray
+    ) -> list[tuple[int, int, float]]:
+        """Expand the 5x5 feature transition matrix into this graph's edges.
+
+        Returns a list of ``(source, destination, probability)`` edges,
+        indexed against ``self.states``.
+
+        Weights are taken directly from the feature matrix. Where several
+        expanded successors share a feature *and* are mutually exclusive
+        under their base constraints -- for instance ``cds_p0_t`` and
+        ``cds_p0_x`` -- each receives the full feature weight rather than a
+        share of it, because which one applies is determined by the
+        sequence, not by chance. :func:`validate_edges` checks that this
+        never lets the feasible weight out of a state exceed 1.
+
+        ``self.include_utr_in_coding_run`` behavior: when set,
+        ``self.min_coding_run_length`` is measured over the 5' UTR plus the
+        coding run rather than the coding run alone, so a long UTR can by
+        itself satisfy the minimum and exempt a short first coding run from
+        the penalty. Only the start side is covered; a symmetric fix for
+        the stop/3' UTR side is not implemented.
+        """
+        p = np.asarray(feature_transition, dtype=float)
+        if p.shape != (N_FEATURES, N_FEATURES):
+            raise ValueError(
+                f"Expected a {N_FEATURES}x{N_FEATURES} matrix; got {p.shape}"
             )
-        for level in range(min_coding_run_length - 3, 0, -1):
-            consumed = min_coding_run_length - level
-            source = f"start_g_lock{level}"
+
+        chain_parts = self._intron_chain_parts()
+        s = self._state_index
+        edges: list[tuple[int, int, float]] = []
+
+        def add(source: str, destination: str, weight: float) -> None:
+            if weight > 0:
+                edges.append((s[source], s[destination], float(weight)))
+
+        cds_cont, cds_intron, cds_end = p[CDS][CDS], p[CDS][IN], p[CDS][U3]
+        utr5_cont, utr5_intron, utr5_end = p[U5][U5], p[U5][IN], p[U5][CDS]
+        intron_stay = p[IN][IN]
+        intron_exit = 1.0 - intron_stay
+
+        # -- intergenic and 5' UTR ------------------------------------------------
+        add("intergenic", "intergenic", p[IG][IG])
+        if self.include_utr_in_coding_run:
+            add(
+                "intergenic",
+                self._locked_destination("utr5", 0),
+                p[IG][U5],
+            )
+        else:
+            add("intergenic", "utr5", p[IG][U5])
+
+        def enter_intron(source: str, intron_class: str, weight: float) -> None:
+            for group in self.splice_motif_groups:
+                add(source, intron_state(intron_class, group.name, "d1"), weight)
+
+        add("utr5", "utr5", utr5_cont)
+        enter_intron("utr5", "utr5", utr5_intron)
+        add("utr5", "start_a", utr5_end)
+
+        if self.include_utr_in_coding_run:
+            for level in range(self.min_coding_run_length - 1, 0, -1):
+                consumed = self.min_coding_run_length - level
+                source = f"utr5_lock{level}"
+                add(source, self._locked_destination("utr5", consumed), utr5_cont)
+                add(source, self._locked_destination("start_a", consumed), utr5_end)
+                penalty = exon_length_penalty(
+                    consumed, self.min_coding_run_length, self.exon_length_strictness
+                )
+                enter_intron(source, "utr5", utr5_intron * penalty)
+
+        # -- start codon ----------------------------------------------------------
+        add("start_a", "start_t", 1.0)
+        add("start_t", "start_g", 1.0)
+
+        def leave_codon_boundary(source: str) -> None:
+            enter_intron(source, "p2", cds_intron)
+            add(source, "cds_p0_t", cds_cont)
+            add(source, "cds_p0_x", cds_cont)
             add(source, "stop_t", cds_end)
-            add(
-                source,
-                exon_lock_destination("p0_t", min_coding_run_length, consumed),
-                cds_cont,
-            )
-            add(
-                source,
-                exon_lock_destination("p0_x", min_coding_run_length, consumed),
-                cds_cont,
-            )
-            penalty = exon_length_penalty(
-                consumed, min_coding_run_length, exon_length_strictness
-            )
-            enter_intron(source, "p2", cds_intron * penalty)
-    else:
-        add(
-            "start_g", exon_lock_destination("p0_t", min_coding_run_length, 3), cds_cont
-        )
-        add(
-            "start_g", exon_lock_destination("p0_x", min_coding_run_length, 3), cds_cont
-        )
-        start_codon_penalty = exon_length_penalty(
-            3, min_coding_run_length, exon_length_strictness
-        )
-        enter_intron("start_g", "p2", cds_intron * start_codon_penalty)
 
-    # -- CDS body -------------------------------------------------------------
-    # Mid-codon there is nowhere to go but onward or into an intron, so the
-    # CDS -> 3' UTR mass folds into continuing.
-    cds_onward = cds_cont + cds_end
+        add("start_g", "stop_t", cds_end)
+        if self.include_utr_in_coding_run:
+            add("start_g", "cds_p0_t", cds_cont)
+            add("start_g", "cds_p0_x", cds_cont)
+            enter_intron("start_g", "p2", cds_intron)
 
-    enter_intron("cds_p0_t", "p0t", cds_intron)
-    add("cds_p0_t", "cds_p1_ta", cds_onward)
-    add("cds_p0_t", "cds_p1_tg", cds_onward)
-    add("cds_p0_t", "cds_p1_safe_t", cds_onward)
-
-    enter_intron("cds_p0_x", "p0x", cds_intron)
-    add("cds_p0_x", "cds_p1_safe_x", cds_onward)
-
-    enter_intron("cds_p1_ta", "p1ta", cds_intron)
-    add("cds_p1_ta", "cds_p2_ta", cds_onward)
-
-    enter_intron("cds_p1_tg", "p1tg", cds_intron)
-    add("cds_p1_tg", "cds_p2_tg", cds_onward)
-
-    for source in ("cds_p1_safe_t", "cds_p1_safe_x"):
-        enter_intron(source, "p1safe", cds_intron)
-        add(source, "cds_p2_safe", cds_onward)
-
-    for source in ("cds_p2_ta", "cds_p2_tg", "cds_p2_safe"):
-        leave_codon_boundary(source)
-
-    # -- terminal stop codon and 3' UTR --------------------------------------
-    add("stop_t", "stop_a", 1.0)
-    add("stop_t", "stop_g", 1.0)
-    add("stop_a", "stop_end_a", 1.0)
-    add("stop_g", "stop_end_g", 1.0)
-    add("stop_end_a", "utr3", 1.0)
-    add("stop_end_g", "utr3", 1.0)
-
-    add("utr3", "utr3", p[U3][U3])
-    enter_intron("utr3", "utr3", p[U3][IN])
-    add("utr3", "intergenic", p[U3][IG])
-
-    # -- intron chains --------------------------------------------------------
-    # Each intron runs donor -> b1..bk -> body* -> acceptor before resuming,
-    # separately per configured motif group (e.g. G -> T/C -> ... -> A -> G for
-    # GT_AG). The b-states are mandatory, which is what imposes the minimum
-    # intron length; the decision to end the intron is taken on leaving the
-    # looping body state, and the acceptor states that follow are forced, so
-    # the exit weight sits on that one edge.
-    resume_weights = {
-        # A 5' UTR intron may resume into more UTR or straight into the start
-        # codon; those two are not mutually exclusive under their masks, so
-        # they share the exit mass in the same ratio a UTR base would transition,
-        # rather than splitting it arbitrarily.
-        "utr5": {
-            "utr5": utr5_cont / (utr5_cont + utr5_end),
-            "start_a": utr5_end / (utr5_cont + utr5_end),
-        },
-        # At a codon boundary the intron resumes into the next codon or into the
-        # terminal stop codon, in the same ratio a coding base would.
-        "p2": {
-            "cds_p0_t": cds_cont / (cds_cont + cds_end),
-            "cds_p0_x": cds_cont / (cds_cont + cds_end),
-            "stop_t": cds_end / (cds_cont + cds_end),
-        },
-    }
-
-    def resume_destination(destination: str) -> str | None:
-        """Where an intron acceptor actually resumes, once the minimum coding
-        run length is accounted for.
-
-        3' UTR is untouched -- min_coding_run_length only governs the run of
-        coding sequence (and, with include_utr_in_coding_run, the 5' UTR
-        preceding it). "stop_t" resuming directly (an intron immediately
-        followed by the stop codon, i.e. a zero-length final exon) is dropped
-        unless the constraint is disabled; the stop codon remains reachable
-        the normal way, once the lock chain is satisfied.
-        """
-        if destination == "stop_t":
-            return "stop_t" if min_coding_run_length <= 0 else None
-        if destination.startswith("cds_"):
-            return exon_lock_destination(
-                destination[len("cds_") :], min_coding_run_length, 0
-            )
-        if include_utr_in_coding_run and destination in ("utr5", "start_a"):
-            # A fresh exon begins here, so the combined UTR+CDS count resets
-            # to 0 just like the CDS-only case above, rather than landing on
-            # the already-unlocked singleton.
-            return locked_destination(destination, min_coding_run_length, 0)
-        return destination
-
-    for intron_class, destinations in INTRON_CLASSES:
-        for group_name, parts in chain_parts.items():
-            chain = [intron_state(intron_class, group_name, part) for part, _ in parts]
-            body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
-            # Donor and the mandatory body positions are a forced march
-            for source, destination in zip(chain, chain[1:-2]):
-                add(source, destination, 1.0)
-            add(body, body, intron_stay)
-            add(body, acceptor_1, intron_exit)
-            add(acceptor_1, acceptor_2, 1.0)
-            weights = resume_weights.get(intron_class, {})
-            for destination in destinations:
-                resolved = resume_destination(destination)
-                if resolved is not None:
-                    add(acceptor_2, resolved, weights.get(destination, 1.0))
-
-    # -- minimum exon length lock chain ---------------------------------------
-    # Level L means "L more bases must be read before the real, intron-capable
-    # CDS states become reachable". Every edge here consumes one base and steps
-    # down exactly one level -- including the codon-boundary (p2 -> p0) step,
-    # not just the mid-codon ones -- so no path can shortcut the count. Level 1
-    # connects directly to the real states rather than a level 0.
-    #
-    # Locked states also get their own (penalized) escape edges -- the same
-    # enter_intron/stop_t options the real states offer, just scaled down by
-    # exon_length_penalty(). That is what makes this a soft preference rather
-    # than the structural ban it used to be: strong emission evidence at that
-    # exact position can still outweigh the penalty.
-    for level in range(min_coding_run_length - 1, 0, -1):
-        for src_suffix, dst_suffix, kind in CDS_PHASE_EDGES:
-            weight = cds_onward if kind == "onward" else cds_cont
-            destination = (
-                f"lock{level - 1}_{dst_suffix}" if level > 1 else f"cds_{dst_suffix}"
-            )
-            add(f"lock{level}_{src_suffix}", destination, weight)
-
-        penalty = exon_length_penalty(
-            min_coding_run_length - level, min_coding_run_length, exon_length_strictness
-        )
-        if penalty > 0:
-            for suffix, _ in CDS_PHASE_STATES:
-                source = f"lock{level}_{suffix}"
-                enter_intron(
-                    source, PHASE_TO_INTRON_CLASS[suffix], cds_intron * penalty
+            for level in range(self.min_coding_run_length - 1, 0, -1):
+                consumed = self.min_coding_run_length - level
+                add(
+                    f"start_a_lock{level}",
+                    self._locked_destination("start_t", consumed),
+                    1.0,
                 )
-                if suffix.startswith("p2_"):
-                    add(source, "stop_t", cds_end * penalty)
+            for level in range(self.min_coding_run_length - 2, 0, -1):
+                consumed = self.min_coding_run_length - level
+                add(
+                    f"start_t_lock{level}",
+                    self._locked_destination("start_g", consumed),
+                    1.0,
+                )
+            for level in range(self.min_coding_run_length - 3, 0, -1):
+                consumed = self.min_coding_run_length - level
+                source = f"start_g_lock{level}"
+                add(source, "stop_t", cds_end)
+                add(source, self._exon_lock_destination("p0_t", consumed), cds_cont)
+                add(source, self._exon_lock_destination("p0_x", consumed), cds_cont)
+                penalty = exon_length_penalty(
+                    consumed, self.min_coding_run_length, self.exon_length_strictness
+                )
+                enter_intron(source, "p2", cds_intron * penalty)
+        else:
+            add("start_g", self._exon_lock_destination("p0_t", 3), cds_cont)
+            add("start_g", self._exon_lock_destination("p0_x", 3), cds_cont)
+            start_codon_penalty = exon_length_penalty(
+                3, self.min_coding_run_length, self.exon_length_strictness
+            )
+            enter_intron("start_g", "p2", cds_intron * start_codon_penalty)
 
-    return edges
+        # -- CDS body -------------------------------------------------------------
+        cds_onward = cds_cont + cds_end
+
+        enter_intron("cds_p0_t", "p0t", cds_intron)
+        add("cds_p0_t", "cds_p1_ta", cds_onward)
+        add("cds_p0_t", "cds_p1_tg", cds_onward)
+        add("cds_p0_t", "cds_p1_safe_t", cds_onward)
+
+        enter_intron("cds_p0_x", "p0x", cds_intron)
+        add("cds_p0_x", "cds_p1_safe_x", cds_onward)
+
+        enter_intron("cds_p1_ta", "p1ta", cds_intron)
+        add("cds_p1_ta", "cds_p2_ta", cds_onward)
+
+        enter_intron("cds_p1_tg", "p1tg", cds_intron)
+        add("cds_p1_tg", "cds_p2_tg", cds_onward)
+
+        for source in ("cds_p1_safe_t", "cds_p1_safe_x"):
+            enter_intron(source, "p1safe", cds_intron)
+            add(source, "cds_p2_safe", cds_onward)
+
+        for source in ("cds_p2_ta", "cds_p2_tg", "cds_p2_safe"):
+            leave_codon_boundary(source)
+
+        # -- terminal stop codon and 3' UTR --------------------------------------
+        add("stop_t", "stop_a", 1.0)
+        add("stop_t", "stop_g", 1.0)
+        add("stop_a", "stop_end_a", 1.0)
+        add("stop_g", "stop_end_g", 1.0)
+        add("stop_end_a", "utr3", 1.0)
+        add("stop_end_g", "utr3", 1.0)
+
+        add("utr3", "utr3", p[U3][U3])
+        enter_intron("utr3", "utr3", p[U3][IN])
+        add("utr3", "intergenic", p[U3][IG])
+
+        # -- intron chains --------------------------------------------------------
+        resume_weights = {
+            "utr5": {
+                "utr5": utr5_cont / (utr5_cont + utr5_end),
+                "start_a": utr5_end / (utr5_cont + utr5_end),
+            },
+            "p2": {
+                "cds_p0_t": cds_cont / (cds_cont + cds_end),
+                "cds_p0_x": cds_cont / (cds_cont + cds_end),
+                "stop_t": cds_end / (cds_cont + cds_end),
+            },
+        }
+
+        def resume_destination(destination: str) -> str | None:
+            if destination == "stop_t":
+                return "stop_t" if self.min_coding_run_length <= 0 else None
+            if destination.startswith("cds_"):
+                return self._exon_lock_destination(destination[len("cds_") :], 0)
+            if self.include_utr_in_coding_run and destination in ("utr5", "start_a"):
+                return self._locked_destination(destination, 0)
+            return destination
+
+        for intron_class, destinations in INTRON_CLASSES:
+            for group_name, parts in chain_parts.items():
+                chain = [
+                    intron_state(intron_class, group_name, part) for part, _ in parts
+                ]
+                body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
+                for source, destination in zip(chain, chain[1:-2]):
+                    add(source, destination, 1.0)
+                add(body, body, intron_stay)
+                add(body, acceptor_1, intron_exit)
+                add(acceptor_1, acceptor_2, 1.0)
+                weights = resume_weights.get(intron_class, {})
+                for destination in destinations:
+                    resolved = resume_destination(destination)
+                    if resolved is not None:
+                        add(acceptor_2, resolved, weights.get(destination, 1.0))
+
+        # -- minimum exon length lock chain ---------------------------------------
+        for level in range(self.min_coding_run_length - 1, 0, -1):
+            for src_suffix, dst_suffix, kind in CDS_PHASE_EDGES:
+                weight = cds_onward if kind == "onward" else cds_cont
+                destination = (
+                    f"lock{level - 1}_{dst_suffix}"
+                    if level > 1
+                    else f"cds_{dst_suffix}"
+                )
+                add(f"lock{level}_{src_suffix}", destination, weight)
+
+            penalty = exon_length_penalty(
+                self.min_coding_run_length - level,
+                self.min_coding_run_length,
+                self.exon_length_strictness,
+            )
+            if penalty > 0:
+                for suffix, _ in CDS_PHASE_STATES:
+                    source = f"lock{level}_{suffix}"
+                    enter_intron(
+                        source, PHASE_TO_INTRON_CLASS[suffix], cds_intron * penalty
+                    )
+                    if suffix.startswith("p2_"):
+                        add(source, "stop_t", cds_end * penalty)
+
+        return edges
+
+    # -- decoding ------------------------------------------------------------
+
+    def decode(
+        self,
+        feature_probs: npt.ArrayLike,
+        base_codes: np.ndarray,
+        feature_transition: npt.ArrayLike,
+        epsilon: float | None = None,
+        return_states: bool = False,
+    ) -> np.ndarray:
+        """Decode per-base feature probabilities under frame and codon constraints.
+
+        See :func:`frame_aware_decode` for parameter documentation --
+        ``feature_probs``/``base_codes``/``feature_transition``/``epsilon``/
+        ``return_states`` mean the same thing here; the five graph config
+        values come from ``self`` instead of being passed in.
+        """
+        feature_probs = np.asarray(feature_probs)
+        if feature_probs.ndim != 2 or feature_probs.shape[1] != N_FEATURES:
+            raise ValueError(
+                f"Expected feature probs of shape (T, 5); got {feature_probs.shape}"
+            )
+        base_codes = np.ascontiguousarray(base_codes, dtype=np.uint8)
+        if base_codes.shape[0] != feature_probs.shape[0]:
+            raise ValueError(
+                f"Sequence length {base_codes.shape[0]} does not match the number of "
+                f"predicted positions {feature_probs.shape[0]}"
+            )
+        if epsilon is None:
+            epsilon = float(np.finfo(np.float32).tiny)
+
+        mask_table = build_mask_table()
+        edges = self.build_edges(np.asarray(feature_transition, dtype=float))
+        validate_edges(edges, mask_table, self.states)
+        index = build_predecessor_csr(edges, len(self.states))
+
+        n_states = len(self.states)
+        initial = np.full(n_states, 1.0 / (10 * n_states))
+        initial[self._state_index["intergenic"]] = 1.0
+        log_initial = np.log(initial / initial.sum())
+
+        log_emission = np.array(feature_probs, dtype=np.float32, copy=True)
+        np.add(log_emission, np.float32(epsilon), out=log_emission)
+        np.log(log_emission, out=log_emission)
+
+        logger.info(
+            f"Frame-aware decoding of {log_emission.shape[0]} positions over "
+            f"{n_states} states ({len(edges)} transitions, "
+            f"{index.n_branch_columns} with back-pointers, "
+            f"min_intron_length={self.min_intron_length}, "
+            f"min_coding_run_length={self.min_coding_run_length}, "
+            f"exon_length_strictness={self.exon_length_strictness}, "
+            f"splice_motif_groups={[g.name for g in self.splice_motif_groups]})"
+        )
+        path = _masked_viterbi(
+            log_emission,
+            base_codes,
+            self.state_feature,
+            self.state_mask,
+            mask_table,
+            index.indptr,
+            index.sources,
+            index.log_weights,
+            index.sole_predecessor,
+            index.branch_column,
+            index.n_branch_columns,
+            log_initial,
+        )
+        if return_states:
+            return path.astype(np.int64)
+        return self.state_feature[path.astype(np.int64)]
+
+
+DEFAULT_GRAPH = FrameStateGraph()
 
 
 def validate_edges(
@@ -853,7 +808,7 @@ def validate_edges(
     silently disable whatever constraint it carries.
     """
     if states is None:
-        states = STATES
+        states = DEFAULT_GRAPH.states
 
     outgoing: dict[int, list[tuple[int, float]]] = {}
     for source, destination, weight in edges:
@@ -907,7 +862,7 @@ def build_predecessor_csr(
     edges: list[tuple[int, int, float]], n_states: int = -1
 ) -> PredecessorIndex:
     if n_states < 0:
-        n_states = N_STATES
+        n_states = len(DEFAULT_GRAPH.states)
     by_destination: dict[int, list[tuple[int, float]]] = {
         j: [] for j in range(n_states)
     }
@@ -1118,79 +1073,17 @@ def frame_aware_decode(
         Feature labels of shape ``(T,)`` with values in ``0..4``, or expanded
         state indices when ``return_states`` is set.
     """
-    feature_probs = np.asarray(feature_probs)
-    if feature_probs.ndim != 2 or feature_probs.shape[1] != N_FEATURES:
-        raise ValueError(
-            f"Expected feature probs of shape (T, 5); got {feature_probs.shape}"
-        )
-    base_codes = np.ascontiguousarray(base_codes, dtype=np.uint8)
-    if base_codes.shape[0] != feature_probs.shape[0]:
-        raise ValueError(
-            f"Sequence length {base_codes.shape[0]} does not match the number of "
-            f"predicted positions {feature_probs.shape[0]}"
-        )
-    if epsilon is None:
-        epsilon = float(np.finfo(np.float32).tiny)
-
-    states = build_states(
-        min_intron_length,
-        splice_motif_groups,
-        min_coding_run_length,
-        include_utr_in_coding_run,
+    graph = FrameStateGraph(
+        min_intron_length=min_intron_length,
+        splice_motif_groups=splice_motif_groups,
+        min_coding_run_length=min_coding_run_length,
+        exon_length_strictness=exon_length_strictness,
+        include_utr_in_coding_run=include_utr_in_coding_run,
     )
-    n_states = len(states)
-    mask_table = build_mask_table()
-    edges = build_edges(
-        np.asarray(feature_transition, dtype=float),
-        min_intron_length,
-        splice_motif_groups,
-        min_coding_run_length,
-        exon_length_strictness,
-        include_utr_in_coding_run,
-    )
-    validate_edges(edges, mask_table, states)
-    index = build_predecessor_csr(edges, n_states)
-
-    state_feature = np.array([state.feature for state in states], dtype=np.int64)
-    state_mask = np.array([state.mask for state in states], dtype=np.int64)
-
-    # The initial distribution is deliberately weak: chromosomes begin in
-    # intergenic sequence, and over millions of positions the choice is
-    # immaterial to the decoded path.
-    initial = np.full(n_states, 1.0 / (10 * n_states))
-    initial[[state.name for state in states].index("intergenic")] = 1.0
-    log_initial = np.log(initial / initial.sum())
-
-    # Build the log-emission array with a single allocation.  At one row per
-    # base this is gigabytes for a large chromosome, so the naive
-    # `np.log(probs + eps)` -- which materialises two more full-size temporaries
-    # -- is worth avoiding.
-    log_emission = np.array(feature_probs, dtype=np.float32, copy=True)
-    np.add(log_emission, np.float32(epsilon), out=log_emission)
-    np.log(log_emission, out=log_emission)
-
-    logger.info(
-        f"Frame-aware decoding of {log_emission.shape[0]} positions over "
-        f"{n_states} states ({len(edges)} transitions, "
-        f"{index.n_branch_columns} with back-pointers, "
-        f"min_intron_length={min_intron_length}, min_coding_run_length={min_coding_run_length}, "
-        f"exon_length_strictness={exon_length_strictness}, "
-        f"splice_motif_groups={[g.name for g in splice_motif_groups]})"
-    )
-    path = _masked_viterbi(
-        log_emission,
+    return graph.decode(
+        feature_probs,
         base_codes,
-        state_feature,
-        state_mask,
-        mask_table,
-        index.indptr,
-        index.sources,
-        index.log_weights,
-        index.sole_predecessor,
-        index.branch_column,
-        index.n_branch_columns,
-        log_initial,
+        feature_transition,
+        epsilon=epsilon,
+        return_states=return_states,
     )
-    if return_states:
-        return path.astype(np.int64)
-    return state_feature[path.astype(np.int64)]

--- a/src/frame_crf.py
+++ b/src/frame_crf.py
@@ -392,10 +392,10 @@ class FrameStateGraph:
     exon_length_strictness: float = DEFAULT_EXON_LENGTH_STRICTNESS
     include_utr_in_coding_run: bool = True
 
-    states: list[State] = field(init=False)
-    state_feature: np.ndarray = field(init=False)
-    state_mask: np.ndarray = field(init=False)
-    _state_index: dict[str, int] = field(init=False)
+    states: list[State] = field(init=False, repr=False, compare=False)
+    state_feature: np.ndarray = field(init=False, repr=False, compare=False)
+    state_mask: np.ndarray = field(init=False, repr=False, compare=False)
+    _state_index: dict[str, int] = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if self.min_intron_length < STRUCTURAL_MIN_INTRON_LENGTH:
@@ -424,10 +424,12 @@ class FrameStateGraph:
     def _intron_chain_parts(self) -> dict[str, list[tuple[str, int]]]:
         """Per-group (suffix, base constraint) lists for the states of one intron.
 
-        See the old module-level ``intron_chain_parts`` docstring (removed)
-        for the full explanation: keyed by :attr:`SpliceMotifGroup.name`,
-        ``b1..bk`` are mandatory body positions imposing the minimum
-        length, and groups never merge.
+        Keyed by :attr:`SpliceMotifGroup.name`. Within a group's chain,
+        ``b1..bk`` are mandatory body positions that impose the minimum
+        length; the looping ``body`` state that follows is what actually
+        absorbs intron length. Groups never merge -- each gets its own
+        donor, body and acceptor states -- so an intron entered through one
+        group's donor can only leave through that same group's acceptor.
         """
         mandatory = self.min_intron_length - STRUCTURAL_MIN_INTRON_LENGTH
         body_parts = [(f"b{i}", MASK_ANY) for i in range(1, mandatory + 1)] + [
@@ -443,6 +445,20 @@ class FrameStateGraph:
         }
 
     def _exon_lock_states(self) -> list[State]:
+        """States that force at least ``self.min_coding_run_length`` bases of
+        coding sequence before intron entry (or the terminal stop) becomes
+        reachable again, mirroring :data:`CDS_PHASE_STATES` at each
+        remaining-length level.
+
+        Level ``L`` means "L more bases must be read before the real,
+        unlocked CDS states -- which do offer intron entry -- become
+        reachable". Every transition consumes one base and steps down
+        exactly one level, so no path can reach an intron or the stop codon
+        before the minimum has elapsed. Level 1 is the last locked level;
+        its own transitions land directly on the real states, so only
+        ``self.min_coding_run_length - 1`` levels are ever materialised,
+        and none at all once ``self.min_coding_run_length <= 1``.
+        """
         return [
             State(f"lock{level}_{suffix}", CDS, mask)
             for level in range(self.min_coding_run_length - 1, 0, -1)
@@ -450,24 +466,64 @@ class FrameStateGraph:
         ]
 
     def _exon_lock_destination(self, suffix: str, already_consumed: int) -> str:
+        """Name of the state to land in for codon-phase ``suffix`` (e.g.
+        ``"p0_t"``), given that ``already_consumed`` bases of the current
+        exon have already been read.
+
+        Returns a locked state if more coding sequence must still be forced
+        before intron entry is legal again, or the real (unlocked) state
+        directly once ``already_consumed`` plus this base already meets
+        ``self.min_coding_run_length``.
+        """
         remaining = self.min_coding_run_length - already_consumed - 1
         if remaining <= 0:
             return f"cds_{suffix}"
         return f"lock{remaining}_{suffix}"
 
     def _locked_destination(self, base_state: str, already_consumed: int) -> str:
+        """Single-track analogue of :meth:`_exon_lock_destination`, for lock
+        chains that have no codon phase to track (5' UTR) or whose phase is
+        fixed (the start codon).
+
+        Returns ``base_state`` once ``already_consumed`` plus this base
+        already meets ``self.min_coding_run_length``, otherwise
+        ``f"{base_state}_lock{N}"``.
+        """
         remaining = self.min_coding_run_length - already_consumed - 1
         if remaining <= 0:
             return base_state
         return f"{base_state}_lock{remaining}"
 
     def _utr5_lock_states(self) -> list[State]:
+        """States that carry a running count of 5' UTR bases consumed so
+        far, used by ``self.include_utr_in_coding_run`` to let a long 5'
+        UTR satisfy ``self.min_coding_run_length`` on its own, so a short
+        first coding run isn't penalized just because the exon's UTR
+        portion isn't counted.
+
+        Mirrors :meth:`_exon_lock_states`, but with a single untyped state
+        per level (5' UTR carries no codon phase) and continuing into the
+        start codon via :meth:`_start_lock_states` rather than resetting at
+        the start codon.
+        """
         return [
             State(f"utr5_lock{level}", U5, MASK_ANY)
             for level in range(self.min_coding_run_length - 1, 0, -1)
         ]
 
     def _start_lock_states(self) -> list[State]:
+        """Locked variants of the start codon (A/T/G) used by
+        ``self.include_utr_in_coding_run`` to carry the running UTR+CDS
+        base count from :meth:`_utr5_lock_states` across the mandatory ATG,
+        which otherwise has no branching point at which to track it.
+
+        Each position can only be reached once at least that many bases
+        (1 for the A, 2 for the T, 3 for the G) have already been
+        consumed, so the reachable level range narrows by one at each
+        position; generating the full ``self.min_coding_run_length - 1``
+        range at every position would otherwise leave unreachable states
+        that fail the graph-connectivity check.
+        """
         specs = [
             ("start_a", MASK_IS_A, 1),
             ("start_t", MASK_IS_T, 2),
@@ -550,6 +606,11 @@ class FrameStateGraph:
             add("intergenic", "utr5", p[IG][U5])
 
         def enter_intron(source: str, intron_class: str, weight: float) -> None:
+            # Each configured motif group's donor mask is mutually exclusive
+            # with every other group's (G-first vs A-first), so -- as with
+            # cds_p0_t / cds_p0_x above -- each gets the full weight rather
+            # than a share of it; only one can ever be feasible for a given
+            # base.
             for group in self.splice_motif_groups:
                 add(source, intron_state(intron_class, group.name, "d1"), weight)
 
@@ -573,6 +634,13 @@ class FrameStateGraph:
         add("start_t", "start_g", 1.0)
 
         def leave_codon_boundary(source: str) -> None:
+            """Successors of a CDS base that completes a codon.
+
+            The next base either opens an intron, continues the coding
+            sequence, or begins the terminal stop codon.  Reaching the 3'
+            UTR is only possible through that stop codon, so the feature
+            matrix's CDS -> 3' UTR mass is what drives entry into it.
+            """
             enter_intron(source, "p2", cds_intron)
             add(source, "cds_p0_t", cds_cont)
             add(source, "cds_p0_x", cds_cont)
@@ -617,6 +685,8 @@ class FrameStateGraph:
             enter_intron("start_g", "p2", cds_intron * start_codon_penalty)
 
         # -- CDS body -------------------------------------------------------------
+        # Mid-codon there is nowhere to go but onward or into an intron, so
+        # the CDS -> 3' UTR mass folds into continuing.
         cds_onward = cds_cont + cds_end
 
         enter_intron("cds_p0_t", "p0t", cds_intron)
@@ -653,11 +723,25 @@ class FrameStateGraph:
         add("utr3", "intergenic", p[U3][IG])
 
         # -- intron chains --------------------------------------------------------
+        # Each intron runs donor -> b1..bk -> body* -> acceptor before
+        # resuming, separately per configured motif group (e.g.
+        # G -> T/C -> ... -> A -> G for GT_AG). The b-states are mandatory,
+        # which is what imposes the minimum intron length; the decision to
+        # end the intron is taken on leaving the looping body state, and the
+        # acceptor states that follow are forced, so the exit weight sits on
+        # that one edge.
         resume_weights = {
+            # A 5' UTR intron may resume into more UTR or straight into the
+            # start codon; those two are not mutually exclusive under their
+            # masks, so they share the exit mass in the same ratio a UTR
+            # base would transition, rather than splitting it arbitrarily.
             "utr5": {
                 "utr5": utr5_cont / (utr5_cont + utr5_end),
                 "start_a": utr5_end / (utr5_cont + utr5_end),
             },
+            # At a codon boundary the intron resumes into the next codon or
+            # into the terminal stop codon, in the same ratio a coding base
+            # would.
             "p2": {
                 "cds_p0_t": cds_cont / (cds_cont + cds_end),
                 "cds_p0_x": cds_cont / (cds_cont + cds_end),
@@ -666,11 +750,25 @@ class FrameStateGraph:
         }
 
         def resume_destination(destination: str) -> str | None:
+            """Where an intron acceptor actually resumes, once the minimum
+            coding run length is accounted for.
+
+            3' UTR is untouched -- ``self.min_coding_run_length`` only
+            governs the run of coding sequence (and, with
+            ``self.include_utr_in_coding_run``, the 5' UTR preceding it).
+            "stop_t" resuming directly (an intron immediately followed by
+            the stop codon, i.e. a zero-length final exon) is dropped unless
+            the constraint is disabled; the stop codon remains reachable the
+            normal way, once the lock chain is satisfied.
+            """
             if destination == "stop_t":
                 return "stop_t" if self.min_coding_run_length <= 0 else None
             if destination.startswith("cds_"):
                 return self._exon_lock_destination(destination[len("cds_") :], 0)
             if self.include_utr_in_coding_run and destination in ("utr5", "start_a"):
+                # A fresh exon begins here, so the combined UTR+CDS count
+                # resets to 0 just like the CDS-only case above, rather than
+                # landing on the already-unlocked singleton.
                 return self._locked_destination(destination, 0)
             return destination
 
@@ -680,6 +778,7 @@ class FrameStateGraph:
                     intron_state(intron_class, group_name, part) for part, _ in parts
                 ]
                 body, acceptor_1, acceptor_2 = chain[-3], chain[-2], chain[-1]
+                # Donor and the mandatory body positions are a forced march.
                 for source, destination in zip(chain, chain[1:-2]):
                     add(source, destination, 1.0)
                 add(body, body, intron_stay)
@@ -692,6 +791,19 @@ class FrameStateGraph:
                         add(acceptor_2, resolved, weights.get(destination, 1.0))
 
         # -- minimum exon length lock chain ---------------------------------------
+        # Level L means "L more bases must be read before the real,
+        # intron-capable CDS states become reachable". Every edge here
+        # consumes one base and steps down exactly one level -- including
+        # the codon-boundary (p2 -> p0) step, not just the mid-codon ones --
+        # so no path can shortcut the count. Level 1 connects directly to
+        # the real states rather than a level 0.
+        #
+        # Locked states also get their own (penalized) escape edges -- the
+        # same enter_intron/stop_t options the real states offer, just
+        # scaled down by exon_length_penalty(). That is what makes this a
+        # soft preference rather than the structural ban it used to be:
+        # strong emission evidence at that exact position can still
+        # outweigh the penalty.
         for level in range(self.min_coding_run_length - 1, 0, -1):
             for src_suffix, dst_suffix, kind in CDS_PHASE_EDGES:
                 weight = cds_onward if kind == "onward" else cds_cont

--- a/src/frame_crf.py
+++ b/src/frame_crf.py
@@ -58,9 +58,9 @@ constraining it, the cheapest way to route around an in-frame stop is a
 *normal-length* intron placed immediately after the start codon or
 immediately after another intron, leaving a coding exon that is just a
 start/stop codon or a couple of leftover bases.  A lock chain (see
-:func:`exon_lock_states`) forces a minimum run of coding sequence before
-intron entry becomes reachable again, the same way the intron body states
-force a minimum intron length -- just for exons instead of introns.
+:class:`FrameStateGraph`'s ``_exon_lock_states``) forces a minimum run of coding
+sequence before intron entry becomes reachable again, the same way the intron
+body states force a minimum intron length -- just for exons instead of introns.
 
 Known limitations
 -----------------
@@ -70,8 +70,8 @@ Known limitations
   :class:`SpliceMotifGroup` gets its own donor, body and acceptor sub-chain,
   since a donor from one group must never resume through another group's
   acceptor. Pass ``splice_motif_groups=(GT_AG, AT_AC)`` to
-  :func:`build_states`/:func:`build_edges`/:func:`frame_aware_decode` to
-  enable them. Motifs beyond GT-AG, GC-AG and AT-AC are not offered: every
+  :class:`FrameStateGraph`/:func:`frame_aware_decode` to enable them. Motifs
+  beyond GT-AG, GC-AG and AT-AC are not offered: every
   other dinucleotide pairing combined accounts for under 0.02% of introns in
   that reference, consistent with annotation noise rather than real splicing.
 * Introns are not permitted to interrupt the start or the stop codon.
@@ -185,9 +185,10 @@ CORE_STATES: list[State] = [
 
 # Introns, one class per coding state they must resume into so that the reading
 # frame survives them.  Each class becomes a chain of states (see
-# `intron_chain_parts`) that forces a canonical donor and acceptor and a minimum
-# length.  This is not cosmetic: without it the decoder dodges an in-frame stop
-# codon by inventing a short "intron" across it, and it does so readily.
+# `FrameStateGraph._intron_chain_parts`) that forces a canonical donor and
+# acceptor and a minimum length.  This is not cosmetic: without it the decoder
+# dodges an in-frame stop codon by inventing a short "intron" across it, and
+# it does so readily.
 INTRON_CLASSES: list[tuple[str, tuple[str, ...]]] = [
     ("utr5", ("utr5", "start_a")),
     ("p0t", ("cds_p1_ta", "cds_p1_tg", "cds_p1_safe_t")),
@@ -226,8 +227,8 @@ AT_AC = SpliceMotifGroup("atac", (MASK_IS_A, MASK_IS_T), (MASK_IS_A, MASK_IS_C))
 # accounts for under 0.02% -- almost certainly annotation noise rather than
 # alternative splicing -- so only AT-AC is offered as an opt-in extra. Adding
 # a group roughly doubles the intron state count (each gets its own donor,
-# body and acceptor sub-chain, see `intron_chain_parts`), so it is off by
-# default; pass ``splice_motif_groups=(GT_AG, AT_AC)`` to enable it.
+# body and acceptor sub-chain, see `FrameStateGraph._intron_chain_parts`), so
+# it is off by default; pass ``splice_motif_groups=(GT_AG, AT_AC)`` to enable it.
 DEFAULT_SPLICE_MOTIF_GROUPS: tuple[SpliceMotifGroup, ...] = (GT_AG,)
 
 # The donor and acceptor account for four bases; a minimum-length intron also
@@ -1040,8 +1041,9 @@ def frame_aware_decode(
         Floor added to probabilities before taking logs.
     return_states
         Return expanded state indices instead of feature labels.  Intended for
-        tests and diagnostics.  Indices refer to
-        ``build_states(min_intron_length, min_coding_run_length=min_coding_run_length)``.
+        tests and diagnostics.  Indices refer to the ``states`` list of the
+        ``FrameStateGraph`` built from this call's config values (see
+        :class:`FrameStateGraph`).
     min_intron_length
         Shortest intron the decoder may emit.  Introns below this length are
         overwhelmingly artefacts of stepping over an in-frame stop codon rather

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -323,3 +323,26 @@ def test_first_in_frame_stop_terminates_the_orf():
         seq, cds_begin=3, cds_stop=len(seq), max_shift=300, min_protein_length=1
     )
     assert orf == (3, 3 + 3 + 15 + 3)
+
+
+def test_kozak_score_returns_none_outside_sequence_bounds():
+    seq = "A" * 5 + "ATG" + "A" * 5  # 13 nt total
+    # ATG is at offset 5; the real window needs 6 nt upstream, which isn't there
+    assert fix_orf.kozak_score(seq, 5) is None
+
+
+def test_kozak_score_returns_none_for_ambiguous_bases():
+    seq = (
+        "N" * fix_orf.KOZAK_WINDOW_UPSTREAM
+        + "ATG"
+        + "A" * fix_orf.KOZAK_WINDOW_DOWNSTREAM
+    )
+    assert fix_orf.kozak_score(seq, fix_orf.KOZAK_WINDOW_UPSTREAM) is None
+
+
+def test_kozak_score_is_deterministic_and_finite():
+    seq = "CGCGCG" + "ATG" + "GCGCGC"
+    score = fix_orf.kozak_score(seq, 6)
+    assert score is not None
+    assert score == fix_orf.kozak_score(seq, 6)  # deterministic
+    assert -1000 < score < 1000  # sane magnitude, not NaN/inf

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -346,3 +346,99 @@ def test_kozak_score_is_deterministic_and_finite():
     assert score is not None
     assert score == fix_orf.kozak_score(seq, 6)  # deterministic
     assert -1000 < score < 1000  # sane magnitude, not NaN/inf
+
+
+# -------------------------------------------------------------------------------------------------
+# first_exon_length and find_best_start_by_kozak (Task 2)
+# -------------------------------------------------------------------------------------------------
+
+
+def test_first_exon_length_single_exon_cds():
+    """CDS entirely within the transcript's last (only) exon: length is the
+    full CDS span."""
+    transcript = fix_orf.Transcript(
+        mrna=None, children=[], seqid="chr1", strand="+",
+        exon_offsets=[0], exons=[(101, 200)],
+    )
+    assert fix_orf.first_exon_length(transcript, begin=10, stop=90) == 80
+
+
+def test_first_exon_length_cds_spanning_a_splice_junction():
+    """CDS starts in the first exon and continues into the second: length is
+    only the portion up to the first splice junction."""
+    transcript = fix_orf.Transcript(
+        mrna=None, children=[], seqid="chr1", strand="+",
+        exon_offsets=[0, 10], exons=[(101, 110), (151, 200)],
+    )
+    assert fix_orf.first_exon_length(transcript, begin=4, stop=22) == 6
+
+
+@pytest.fixture
+def tiny_kozak_pwm(monkeypatch):
+    """A 2-up/2-down window PWM that strongly prefers C at position -2 and
+    position +2, and is neutral everywhere else -- gives every test in this
+    file a predictable, hand-computable Kozak score."""
+    monkeypatch.setattr(fix_orf, "KOZAK_WINDOW_UPSTREAM", 2)
+    monkeypatch.setattr(fix_orf, "KOZAK_WINDOW_DOWNSTREAM", 2)
+    strong = (-4.0, 4.0, -4.0, -4.0)  # prefers C
+    neutral = (0.0, 0.0, 0.0, 0.0)
+    monkeypatch.setattr(
+        fix_orf,
+        "KOZAK_PWM_LOG_ODDS",
+        (strong, neutral, neutral, neutral, neutral, neutral, strong),
+    )
+    monkeypatch.setattr(fix_orf, "KOZAK_BACKGROUND", (0.25, 0.25, 0.25, 0.25))
+
+
+# Shared 26 nt spliced sequence for find_best_start_by_kozak and
+# repair_transcript tests below. Two in-frame ATGs, 9 nt (3 codons) apart so
+# they share a reading frame and a stop codon:
+#   t[0:4)    leading (no ATG)
+#   t[4:7)    "weak" candidate ATG
+#   t[7:10)   codon (Lys)
+#   t[10:13)  codon (Ala) -- also carries the "strong" candidate's -2/-1 context
+#   t[13:16)  "strong" candidate ATG (also codon 3 of the weak-start ORF)
+#   t[16:19)  codon (Ser/Leu) -- also carries the "strong" candidate's +1/+2 context
+#   t[19:22)  TAA stop, shared by both candidates (same frame)
+#   t[22:26)  trailing (no ATG)
+# "WEAK_STRONG": weak candidate has poor Kozak context, strong candidate has
+# good Kozak context -- this is the sequence used by the "should repair" test.
+WEAK_STRONG_SEQ = "CCAAATGAAAGCGATGTCATAACCCC"
+# "STRONG_WEAK": flip which candidate has the good context -- the original
+# (short) start is well-supported and must be left alone.
+STRONG_WEAK_SEQ = "CCCAATGACAGAGATGTTATAACCCC"
+# "WEAK_WEAK": neither candidate has good context -- nothing to switch to,
+# should be flagged instead.
+WEAK_WEAK_SEQ = "CCAAATGAAAGAGATGTTATAACCCC"
+
+
+def test_find_best_start_by_kozak_prefers_the_better_scoring_candidate(tiny_kozak_pwm):
+    result = fix_orf.find_best_start_by_kozak(
+        WEAK_STRONG_SEQ, cds_begin=4, cds_stop=22, max_shift=300, min_protein_length=1
+    )
+    assert result is not None
+    begin, stop, score = result
+    assert (begin, stop) == (13, 22)
+    assert score == pytest.approx(8.0)
+
+
+def test_find_best_start_by_kozak_can_return_the_original_when_it_scores_best(tiny_kozak_pwm):
+    result = fix_orf.find_best_start_by_kozak(
+        STRONG_WEAK_SEQ, cds_begin=4, cds_stop=22, max_shift=300, min_protein_length=1
+    )
+    assert result is not None
+    begin, stop, score = result
+    assert (begin, stop) == (4, 22)
+    assert score == pytest.approx(8.0)
+
+
+def test_find_best_start_by_kozak_returns_none_outside_the_shift_window(tiny_kozak_pwm):
+    """The strong candidate is 9 nt from cds_begin; a 3 nt window excludes it,
+    so only the (weak) original is a valid candidate."""
+    result = fix_orf.find_best_start_by_kozak(
+        WEAK_STRONG_SEQ, cds_begin=4, cds_stop=22, max_shift=3, min_protein_length=1
+    )
+    assert result is not None
+    begin, stop, score = result
+    assert (begin, stop) == (4, 22)
+    assert score == pytest.approx(-8.0)

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -479,15 +479,15 @@ def test_find_best_start_by_kozak_never_returns_an_out_of_frame_candidate(
     and ties offset 30's score, so it (wrongly) wins.  With the filter,
     offset 13 is skipped entirely and offset 30 is the correct winner.
     """
-    seq = list("C" * 45)
+    chars = list("C" * 45)
 
     def set_codon(i: int, codon: str) -> None:
-        seq[i : i + 3] = list(codon)
+        chars[i : i + 3] = list(codon)
 
     cds_begin = 6
     set_codon(cds_begin, "ATG")
-    seq[cds_begin - 2] = "A"  # weak: non-C at -2
-    seq[cds_begin + 4] = "A"  # weak: non-C at +2
+    chars[cds_begin - 2] = "A"  # weak: non-C at -2
+    chars[cds_begin + 4] = "A"  # weak: non-C at +2
 
     out_of_frame = cds_begin + 7  # 13, not a multiple of 3 from cds_begin
     set_codon(out_of_frame, "ATG")
@@ -498,7 +498,7 @@ def test_find_best_start_by_kozak_never_returns_an_out_of_frame_candidate(
     set_codon(22, "TAA")  # first in-frame stop for out_of_frame's own class
     set_codon(39, "TAA")  # first in-frame stop for cds_begin/in_frame_alt's class
 
-    seq = "".join(seq)
+    seq = "".join(chars)
 
     result = fix_orf.find_best_start_by_kozak(
         seq, cds_begin=cds_begin, cds_stop=42, max_shift=300, min_protein_length=1
@@ -539,22 +539,22 @@ def test_find_best_start_by_kozak_rejects_a_disjoint_upstream_orf(tiny_kozak_pwm
     Offset 8 is in cds_begin's reading frame (20 - 8 = 12) and scores
     higher, so without the stop-preserving filter it would wrongly win.
     """
-    seq = list("C" * 40)
+    chars = list("C" * 40)
 
     def set_codon(i: int, codon: str) -> None:
-        seq[i : i + 3] = list(codon)
+        chars[i : i + 3] = list(codon)
 
     set_codon(8, "ATG")  # disjoint upstream ATG, strong context
     set_codon(14, "TAA")  # its own forced stop -- not cds_stop
 
     cds_begin = 20
     set_codon(cds_begin, "ATG")
-    seq[cds_begin - 2] = "A"  # weak: non-C at -2
-    seq[cds_begin + 4] = "A"  # weak: non-C at +2
+    chars[cds_begin - 2] = "A"  # weak: non-C at -2
+    chars[cds_begin + 4] = "A"  # weak: non-C at +2
     set_codon(32, "TAA")  # cds_begin's real forced stop
     cds_stop = 35
 
-    seq = "".join(seq)
+    seq = "".join(chars)
 
     result = fix_orf.find_best_start_by_kozak(
         seq, cds_begin=cds_begin, cds_stop=cds_stop, max_shift=300, min_protein_length=1

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -773,3 +773,134 @@ def test_weak_start_search_does_not_trigger_for_a_long_first_exon(
     assert stats["repaired"] == 0
     _, records = fix_orf.read_gff(str(out))
     assert exonic(records) == sorted(blocks)
+
+
+# -------------------------------------------------------------------------------------------------
+# calibrate_kozak_margin
+# -------------------------------------------------------------------------------------------------
+
+
+def test_calibrate_kozak_margin_falls_back_when_too_few_confident_transcripts(
+    tmp_path,
+):
+    """An empty (or near-empty) genome has nothing to calibrate against --
+    calibrate_kozak_margin must return the default unchanged rather than
+    over-fitting a margin to a handful of transcripts."""
+    fasta = tmp_path / "genome.fa"
+    fasta.write_text(">chr1\n" + FLANK + "\n")
+    margin = fix_orf.calibrate_kozak_margin(
+        by_seqid={},
+        input_fasta=str(fasta),
+        max_shift=300,
+        min_protein_length=1,
+        weak_start_threshold=9,
+        default_margin=3.0,
+    )
+    assert margin == 3.0
+
+
+def build_confident_loci_chromosome(n: int) -> tuple[str, str]:
+    """n single-exon transcripts on chr1, each using WEAK_STRONG_SEQ's ORF: a
+    poor-Kozak-context start that is nonetheless the correct one, because the
+    exon it sits in is long enough that first_exon_length never dips below a
+    realistic weak_start_threshold. Every one of these is exactly the kind of
+    already-known-correct, unambiguous start calibrate_kozak_margin measures
+    against -- and because WEAK_STRONG_SEQ's alternate (offset 13) ATG always
+    outscores the true start, every one registers as a transcript the
+    uncalibrated default margin would wrongly switch away from.
+
+    Returns (gff_text, fasta_text).
+    """
+    locus_len = len(WEAK_STRONG_SEQ)
+    gap = 20
+    lines = ["##gff-version 3"]
+    body = []
+    for i in range(n):
+        start = 101 + i * (locus_len + gap)
+        gid, tid = f"g{i}", f"g{i}.t1"
+        lines.append(
+            f"chr1\ttest\tgene\t{start}\t{start + locus_len - 1}\t.\t+\t.\tID={gid}"
+        )
+        lines.append(
+            f"chr1\ttest\tmRNA\t{start}\t{start + locus_len - 1}\t.\t+\t.\tID={tid};Parent={gid}"
+        )
+        lines.append(
+            f"chr1\ttest\tfive_prime_UTR\t{start}\t{start + 3}\t.\t+\t.\tParent={tid}"
+        )
+        lines.append(
+            f"chr1\ttest\tCDS\t{start + 4}\t{start + 21}\t.\t+\t0\tParent={tid}"
+        )
+        lines.append(
+            f"chr1\ttest\tthree_prime_UTR\t{start + 22}\t{start + locus_len - 1}\t.\t+\t.\tParent={tid}"
+        )
+        body.append(WEAK_STRONG_SEQ + "T" * gap)
+    gff = "\n".join(lines) + "\n"
+    fasta = ">chr1\n" + FLANK + "".join(body) + FLANK + "\n"
+    return gff, fasta
+
+
+def run_calibration_scenario(tmp_path, n_confident, calibrate_margin):
+    """n_confident WEAK_STRONG_SEQ loci on chr1 (see
+    build_confident_loci_chromosome), plus one genuinely ambiguous
+    short-first-exon WEAK_STRONG_SEQ transcript on chr2 (same shape as
+    test_weak_start_with_a_better_candidate_is_repaired). Returns the
+    ambiguous transcript's mRNA attributes."""
+    confident_gff, confident_fasta = build_confident_loci_chromosome(n_confident)
+    # g1/g1.t1 collides with build_confident_loci_chromosome's own i=1 locus
+    # (Parent lookups are by ID regardless of seqid) -- rename to a unique ID.
+    ambiguous_gff = (
+        build_gff(WEAK_START_BLOCKS, "+")
+        .replace("chr1", "chr2")
+        .replace("Parent=g1.t1", "Parent=gamb.t1")
+        .replace("ID=g1.t1;Parent=g1", "ID=gamb.t1;Parent=gamb")
+        .replace("ID=g1\n", "ID=gamb\n")
+    )
+    ambiguous_fasta = ">chr2\n" + build_weak_start_chromosome(WEAK_STRONG_SEQ) + "\n"
+
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(confident_gff + "\n".join(ambiguous_gff.splitlines()[1:]) + "\n")
+    fasta.write_text(confident_fasta + ambiguous_fasta)
+
+    fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        max_shift=300,
+        min_protein_length=1,
+        require_canonical=True,
+        report_path=None,
+        fix_weak_starts=True,
+        weak_start_threshold=9,
+        kozak_margin=3.0,
+        weak_kozak_threshold=0.0,
+        calibrate_margin=calibrate_margin,
+    )
+    _, records = fix_orf.read_gff(str(out))
+    return next(r.attributes for r in records if r.type == "mRNA" and r.seqid == "chr2")
+
+
+def test_calibrated_margin_blocks_a_switch_the_default_margin_would_make(
+    tiny_kozak_pwm, tmp_path
+):
+    """250 confident transcripts all show the default margin would switch
+    away from a known-correct start (WEAK_STRONG_SEQ's alternate always
+    outscores its true start) -- calibration should pick this up and raise
+    the margin enough that the same switch no longer fires on a genuinely
+    ambiguous transcript with an identical score gap."""
+    attributes = run_calibration_scenario(tmp_path, 250, calibrate_margin=True)
+    assert attributes["orf_status"] == "complete"
+    assert (
+        "orf_issue" not in attributes or attributes["orf_issue"] != "weak_start_kozak"
+    )
+
+
+def test_calibration_can_be_turned_off(tiny_kozak_pwm, tmp_path):
+    """The same scenario with calibration disabled falls back to the fixed
+    default margin, which switches -- confirming the previous test's
+    "left alone" result comes from calibration, not from something else in
+    the fixture blocking the switch."""
+    attributes = run_calibration_scenario(tmp_path, 250, calibrate_margin=False)
+    assert attributes["orf_status"] == "repaired"
+    assert attributes["orf_issue"] == "weak_start_kozak"

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -344,12 +344,45 @@ def test_kozak_score_returns_none_for_ambiguous_bases():
     assert fix_orf.kozak_score(seq, fix_orf.KOZAK_WINDOW_UPSTREAM) is None
 
 
-def test_kozak_score_is_deterministic_and_finite():
-    seq = "CGCGCG" + "ATG" + "GCGCGC"
-    score = fix_orf.kozak_score(seq, 6)
+KOZAK_TEST_WINDOWS = [
+    "CGCGCG" + "ATG" + "GCGCGC",
+    "AAAAAA" + "ATG" + "TTTTTT",
+    "TGCATG" + "ATG" + "CATGCA",
+    "GGGGGG" + "ATG" + "AAAAAA",
+]
+
+
+@pytest.mark.parametrize("seq", KOZAK_TEST_WINDOWS)
+def test_kozak_score_is_deterministic(seq):
+    score = fix_orf.kozak_score(seq, fix_orf.KOZAK_WINDOW_UPSTREAM)
     assert score is not None
-    assert score == fix_orf.kozak_score(seq, 6)  # deterministic
-    assert -1000 < score < 1000  # sane magnitude, not NaN/inf
+    assert score == fix_orf.kozak_score(seq, fix_orf.KOZAK_WINDOW_UPSTREAM)
+
+
+def test_kozak_score_bounded_by_pwm_extremes():
+    """kozak_score is a per-column sum over a fixed table, so every window's
+    score falls between the sum of the row minima and the sum of the row
+    maxima. The window built from each column's best (worst) base hits that
+    bound exactly."""
+    max_window = "".join(
+        "ACGT"[row.index(max(row))] for row in fix_orf.KOZAK_PWM_LOG_ODDS
+    )
+    min_window = "".join(
+        "ACGT"[row.index(min(row))] for row in fix_orf.KOZAK_PWM_LOG_ODDS
+    )
+    max_score = sum(max(row) for row in fix_orf.KOZAK_PWM_LOG_ODDS)
+    min_score = sum(min(row) for row in fix_orf.KOZAK_PWM_LOG_ODDS)
+
+    assert fix_orf.kozak_score(
+        max_window, fix_orf.KOZAK_WINDOW_UPSTREAM
+    ) == pytest.approx(max_score)
+    assert fix_orf.kozak_score(
+        min_window, fix_orf.KOZAK_WINDOW_UPSTREAM
+    ) == pytest.approx(min_score)
+
+    for seq in KOZAK_TEST_WINDOWS:
+        score = fix_orf.kozak_score(seq, fix_orf.KOZAK_WINDOW_UPSTREAM)
+        assert min_score <= score <= max_score
 
 
 # -------------------------------------------------------------------------------------------------

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -100,6 +100,10 @@ def run(tmp_path, blocks, strand, intron=CANONICAL_INTRON, **kwargs):
         "min_protein_length": 10,
         "require_canonical": True,
         "report_path": None,
+        "fix_weak_starts": True,
+        "weak_start_threshold": 9,
+        "kozak_margin": 1.0,
+        "weak_kozak_threshold": 0.0,
     }
     options.update(kwargs)
     stats = fix_orf.fix_orf(
@@ -357,8 +361,12 @@ def test_first_exon_length_single_exon_cds():
     """CDS entirely within the transcript's last (only) exon: length is the
     full CDS span."""
     transcript = fix_orf.Transcript(
-        mrna=None, children=[], seqid="chr1", strand="+",
-        exon_offsets=[0], exons=[(101, 200)],
+        mrna=None,
+        children=[],
+        seqid="chr1",
+        strand="+",
+        exon_offsets=[0],
+        exons=[(101, 200)],
     )
     assert fix_orf.first_exon_length(transcript, begin=10, stop=90) == 80
 
@@ -367,8 +375,12 @@ def test_first_exon_length_cds_spanning_a_splice_junction():
     """CDS starts in the first exon and continues into the second: length is
     only the portion up to the first splice junction."""
     transcript = fix_orf.Transcript(
-        mrna=None, children=[], seqid="chr1", strand="+",
-        exon_offsets=[0, 10], exons=[(101, 110), (151, 200)],
+        mrna=None,
+        children=[],
+        seqid="chr1",
+        strand="+",
+        exon_offsets=[0, 10],
+        exons=[(101, 110), (151, 200)],
     )
     assert fix_orf.first_exon_length(transcript, begin=4, stop=22) == 6
 
@@ -422,7 +434,9 @@ def test_find_best_start_by_kozak_prefers_the_better_scoring_candidate(tiny_koza
     assert score == pytest.approx(8.0)
 
 
-def test_find_best_start_by_kozak_can_return_the_original_when_it_scores_best(tiny_kozak_pwm):
+def test_find_best_start_by_kozak_can_return_the_original_when_it_scores_best(
+    tiny_kozak_pwm,
+):
     result = fix_orf.find_best_start_by_kozak(
         STRONG_WEAK_SEQ, cds_begin=4, cds_stop=22, max_shift=300, min_protein_length=1
     )
@@ -442,3 +456,153 @@ def test_find_best_start_by_kozak_returns_none_outside_the_shift_window(tiny_koz
     begin, stop, score = result
     assert (begin, stop) == (4, 22)
     assert score == pytest.approx(-8.0)
+
+
+# -------------------------------------------------------------------------------------------------
+# repair_transcript weak-start end-to-end wiring (Task 3)
+# -------------------------------------------------------------------------------------------------
+
+# Genomic layout for the weak-start tests below (plus strand):
+#   FLANK(100) | exon1 (101-110, 10nt) | intron (111-150, 40nt canonical) |
+#   exon2 (151-166, 16nt) | FLANK(100)
+# Spliced transcript = exon1 + exon2 = the 26 nt sequences from Task 2.
+WEAK_START_INTRON = "GT" + "T" * 36 + "AG"  # 40 nt, canonical
+
+# Original (input) annotation: CDS = genomic (105,110)+(151,162), a 6 nt
+# first coding exon -- already a *complete*, valid ORF (matches
+# WEAK_STRONG_SEQ / STRONG_WEAK_SEQ / WEAK_WEAK_SEQ's t[4:22) ORF), so it
+# will hit the new is_complete_orf branch rather than the existing repair
+# path.
+WEAK_START_BLOCKS = [
+    (101, 104, "five_prime_UTR", "."),
+    (105, 110, "CDS", "0"),
+    (151, 162, "CDS", "0"),
+    (163, 166, "three_prime_UTR", "."),
+]
+
+
+def build_weak_start_chromosome(spliced_seq: str) -> str:
+    exon1, exon2 = spliced_seq[:10], spliced_seq[10:]
+    locus = exon1 + WEAK_START_INTRON + exon2
+    assert len(locus) == 10 + 40 + 16
+    return FLANK + locus + FLANK
+
+
+def run_weak_start(tmp_path, spliced_seq, **kwargs):
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    gff.write_text(build_gff(WEAK_START_BLOCKS, "+"))
+    fasta.write_text(">chr1\n" + build_weak_start_chromosome(spliced_seq) + "\n")
+
+    options: dict[str, object] = {
+        "max_shift": 300,
+        "min_protein_length": 1,
+        "require_canonical": True,
+        "report_path": None,
+        "fix_weak_starts": True,
+        "weak_start_threshold": 9,
+        "kozak_margin": 1.0,
+        "weak_kozak_threshold": 0.0,
+    }
+    options.update(kwargs)
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        **options,  # pyrefly: ignore[bad-argument-type]
+    )
+    _, records = fix_orf.read_gff(str(out))
+    return stats, records
+
+
+def test_weak_start_with_a_better_candidate_is_repaired(tiny_kozak_pwm, tmp_path):
+    stats, records = run_weak_start(tmp_path, WEAK_STRONG_SEQ)
+
+    assert stats["repaired"] == 1
+    assert exonic(records) == sorted(
+        [
+            (101, 110, "five_prime_UTR", "."),
+            (151, 153, "five_prime_UTR", "."),
+            (154, 162, "CDS", "0"),
+            (163, 166, "three_prime_UTR", "."),
+        ]
+    )
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "repaired"
+    assert attributes["orf_issue"] == "weak_start_kozak"
+
+
+def test_genuinely_well_supported_short_first_exon_is_left_alone(
+    tiny_kozak_pwm, tmp_path
+):
+    stats, records = run_weak_start(tmp_path, STRONG_WEAK_SEQ)
+
+    assert stats["complete"] == 1
+    assert stats["repaired"] == 0
+    assert exonic(records) == sorted(WEAK_START_BLOCKS)
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "complete"
+    assert "orf_issue" not in attributes
+
+
+def test_weak_start_with_no_good_candidate_is_flagged_not_repaired(
+    tiny_kozak_pwm, tmp_path
+):
+    stats, records = run_weak_start(tmp_path, WEAK_WEAK_SEQ)
+
+    assert stats["complete"] == 1
+    assert stats["repaired"] == 0
+    assert exonic(records) == sorted(WEAK_START_BLOCKS)
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "complete"
+    assert attributes["orf_issue"] == "weak_kozak_support"
+
+
+def test_fix_weak_starts_can_be_opted_out(tiny_kozak_pwm, tmp_path):
+    """The same sequence that gets repaired by default must be left
+    completely alone with --no-fix-weak-starts (fix_weak_starts=False)."""
+    stats, records = run_weak_start(tmp_path, WEAK_STRONG_SEQ, fix_weak_starts=False)
+
+    assert stats["repaired"] == 0
+    assert stats["complete"] == 1
+    assert exonic(records) == sorted(WEAK_START_BLOCKS)
+    assert "orf_issue" not in mrna_attributes(records)
+
+
+def test_weak_start_search_does_not_trigger_for_a_long_first_exon(
+    tiny_kozak_pwm, tmp_path
+):
+    """A transcript whose first exon is already >= weak_start_threshold must
+    not be touched, even with a weak Kozak score -- this only reuses
+    WEAK_STRONG_SEQ's sequence bytes but treats the whole thing as single
+    long exon by not splitting it across a splice junction, so
+    first_exon_length is the full 18 nt CDS length, well above the
+    threshold."""
+    gff = tmp_path / "in.gff"
+    fasta = tmp_path / "genome.fa"
+    out = tmp_path / "out.gff"
+    # Single-exon layout: the whole spliced sequence in one genomic block.
+    blocks = [
+        (101, 104, "five_prime_UTR", "."),
+        (105, 122, "CDS", "0"),
+        (123, 126, "three_prime_UTR", "."),
+    ]
+    gff.write_text(build_gff(blocks, "+"))
+    fasta.write_text(">chr1\n" + FLANK + WEAK_STRONG_SEQ + FLANK + "\n")
+    stats = fix_orf.fix_orf(
+        input_gff=str(gff),
+        input_fasta=str(fasta),
+        output_gff=str(out),
+        max_shift=300,
+        min_protein_length=1,
+        require_canonical=True,
+        report_path=None,
+        fix_weak_starts=True,
+        weak_start_threshold=9,
+        kozak_margin=1.0,
+        weak_kozak_threshold=0.0,
+    )
+    assert stats["repaired"] == 0
+    _, records = fix_orf.read_gff(str(out))
+    assert exonic(records) == sorted(blocks)

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -353,7 +353,7 @@ def test_kozak_score_is_deterministic_and_finite():
 
 
 # -------------------------------------------------------------------------------------------------
-# first_exon_length and find_best_start_by_kozak (Task 2)
+# first_exon_length and find_best_start_by_kozak
 # -------------------------------------------------------------------------------------------------
 
 
@@ -573,13 +573,13 @@ def test_find_best_start_by_kozak_rejects_a_disjoint_upstream_orf(tiny_kozak_pwm
 
 
 # -------------------------------------------------------------------------------------------------
-# repair_transcript weak-start end-to-end wiring (Task 3)
+# repair_transcript weak-start end-to-end wiring
 # -------------------------------------------------------------------------------------------------
 
 # Genomic layout for the weak-start tests below (plus strand):
 #   FLANK(100) | exon1 (101-110, 10nt) | intron (111-150, 40nt canonical) |
 #   exon2 (151-166, 16nt) | FLANK(100)
-# Spliced transcript = exon1 + exon2 = the 26 nt sequences from Task 2.
+# Spliced transcript = exon1 + exon2 = the same 26 nt sequences used above.
 WEAK_START_INTRON = "GT" + "T" * 36 + "AG"  # 40 nt, canonical
 WEAK_START_NONCANONICAL_INTRON = "AA" + "T" * 36 + "CC"  # 40 nt, non-canonical
 

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -102,8 +102,8 @@ def run(tmp_path, blocks, strand, intron=CANONICAL_INTRON, **kwargs):
         "report_path": None,
         "fix_weak_starts": True,
         "weak_start_threshold": 9,
-        "kozak_margin": 1.0,
-        "weak_kozak_threshold": 0.0,
+        "kozak_margin": 0.5,
+        "weak_kozak_threshold": 5.0,
     }
     options.update(kwargs)
     stats = fix_orf.fix_orf(
@@ -458,6 +458,120 @@ def test_find_best_start_by_kozak_returns_none_outside_the_shift_window(tiny_koz
     assert score == pytest.approx(-8.0)
 
 
+def test_find_best_start_by_kozak_never_returns_an_out_of_frame_candidate(
+    tiny_kozak_pwm,
+):
+    """Regression for the frame-changing switch bug: an out-of-frame ATG with
+    a strong Kozak context must lose to an in-frame ATG with an equally
+    strong context, even though the out-of-frame candidate is found first
+    and would win under a pure score comparison.
+
+    Layout (offsets in a 45 nt sequence, all non-codon positions filled with
+    neutral 'C'):
+      offset 6   cds_begin's own ATG, weak context (non-C at -2/+2) -> -8.0
+      offset 13  out-of-frame ATG (13 - 6 = 7, not a multiple of 3), strong
+                 context (default 'C' filler at -2/+2) -> +8.0, with its own
+                 downstream in-frame (class 1 mod 3) TAA stop at offset 22
+      offset 30  in-frame ATG (30 - 6 = 24, a multiple of 3), strong context
+                 -> +8.0, sharing cds_begin's downstream in-frame (class 0
+                 mod 3) TAA stop at offset 39
+    Without the frame filter, offset 13 is encountered first during the scan
+    and ties offset 30's score, so it (wrongly) wins.  With the filter,
+    offset 13 is skipped entirely and offset 30 is the correct winner.
+    """
+    seq = list("C" * 45)
+
+    def set_codon(i: int, codon: str) -> None:
+        seq[i : i + 3] = list(codon)
+
+    cds_begin = 6
+    set_codon(cds_begin, "ATG")
+    seq[cds_begin - 2] = "A"  # weak: non-C at -2
+    seq[cds_begin + 4] = "A"  # weak: non-C at +2
+
+    out_of_frame = cds_begin + 7  # 13, not a multiple of 3 from cds_begin
+    set_codon(out_of_frame, "ATG")
+
+    in_frame_alt = cds_begin + 24  # 30, a multiple of 3 from cds_begin
+    set_codon(in_frame_alt, "ATG")
+
+    set_codon(22, "TAA")  # first in-frame stop for out_of_frame's own class
+    set_codon(39, "TAA")  # first in-frame stop for cds_begin/in_frame_alt's class
+
+    seq = "".join(seq)
+
+    result = fix_orf.find_best_start_by_kozak(
+        seq, cds_begin=cds_begin, cds_stop=42, max_shift=300, min_protein_length=1
+    )
+
+    assert result is not None
+    begin, stop, score = result
+    assert (begin - cds_begin) % 3 == 0, (
+        f"find_best_start_by_kozak returned an out-of-frame candidate: "
+        f"begin={begin}, cds_begin={cds_begin}"
+    )
+    assert (begin, stop) == (in_frame_alt, 42)
+    assert score == pytest.approx(8.0)
+    # The frame-preserving property this fix guarantees: a same-frame switch
+    # can never move the stop codon.
+    assert stop == 42
+
+
+def test_find_best_start_by_kozak_rejects_a_disjoint_upstream_orf(tiny_kozak_pwm):
+    """Regression, found on real Oropetium thomaeum production data: a
+    same-frame ATG is not automatically part of the *same* ORF. An ATG
+    upstream of cds_begin, still inside the exonic (e.g. 5' UTR) sequence,
+    can have its own short in-frame stop before ever reaching cds_begin --
+    a disjoint little ORF (a real uORF, or just incidental sequence) that
+    happens to score well on Kozak context alone, since kozak_score() only
+    looks at the +/-6 nt immediately around the ATG. Switching to it would
+    silently replace the gene's actual protein with this unrelated
+    fragment. find_best_start_by_kozak must reject any candidate whose own
+    forced stop is not cds_stop itself, even when it shares cds_begin's
+    reading frame and out-scores the real start.
+
+    Layout (40 nt, 'C' filler elsewhere):
+      offset 8   disjoint upstream ATG, strong context (default 'C' filler
+                 at -2/+2) -> +8.0, but its own first in-frame stop is at
+                 offset 14 (TAA) -- 9 nt later, nowhere near cds_stop.
+      offset 20  cds_begin, weak context (non-C at -2/+2) -> -8.0, whose
+                 real forced stop is the TAA at offset 32 (cds_stop = 35).
+    Offset 8 is in cds_begin's reading frame (20 - 8 = 12) and scores
+    higher, so without the stop-preserving filter it would wrongly win.
+    """
+    seq = list("C" * 40)
+
+    def set_codon(i: int, codon: str) -> None:
+        seq[i : i + 3] = list(codon)
+
+    set_codon(8, "ATG")  # disjoint upstream ATG, strong context
+    set_codon(14, "TAA")  # its own forced stop -- not cds_stop
+
+    cds_begin = 20
+    set_codon(cds_begin, "ATG")
+    seq[cds_begin - 2] = "A"  # weak: non-C at -2
+    seq[cds_begin + 4] = "A"  # weak: non-C at +2
+    set_codon(32, "TAA")  # cds_begin's real forced stop
+    cds_stop = 35
+
+    seq = "".join(seq)
+
+    result = fix_orf.find_best_start_by_kozak(
+        seq, cds_begin=cds_begin, cds_stop=cds_stop, max_shift=300, min_protein_length=1
+    )
+
+    assert result is not None
+    begin, stop, score = result
+    assert stop == cds_stop, (
+        f"find_best_start_by_kozak returned a candidate whose forced stop "
+        f"({stop}) is not the original cds_stop ({cds_stop}) -- it switched "
+        f"to a disjoint ORF instead of a different start for the same one."
+    )
+    # With the disjoint candidate correctly excluded, only the (weak)
+    # original remains a valid candidate.
+    assert (begin, stop, score) == (cds_begin, cds_stop, pytest.approx(-8.0))
+
+
 # -------------------------------------------------------------------------------------------------
 # repair_transcript weak-start end-to-end wiring (Task 3)
 # -------------------------------------------------------------------------------------------------
@@ -467,6 +581,7 @@ def test_find_best_start_by_kozak_returns_none_outside_the_shift_window(tiny_koz
 #   exon2 (151-166, 16nt) | FLANK(100)
 # Spliced transcript = exon1 + exon2 = the 26 nt sequences from Task 2.
 WEAK_START_INTRON = "GT" + "T" * 36 + "AG"  # 40 nt, canonical
+WEAK_START_NONCANONICAL_INTRON = "AA" + "T" * 36 + "CC"  # 40 nt, non-canonical
 
 # Original (input) annotation: CDS = genomic (105,110)+(151,162), a 6 nt
 # first coding exon -- already a *complete*, valid ORF (matches
@@ -481,19 +596,23 @@ WEAK_START_BLOCKS = [
 ]
 
 
-def build_weak_start_chromosome(spliced_seq: str) -> str:
+def build_weak_start_chromosome(
+    spliced_seq: str, intron: str = WEAK_START_INTRON
+) -> str:
     exon1, exon2 = spliced_seq[:10], spliced_seq[10:]
-    locus = exon1 + WEAK_START_INTRON + exon2
+    locus = exon1 + intron + exon2
     assert len(locus) == 10 + 40 + 16
     return FLANK + locus + FLANK
 
 
-def run_weak_start(tmp_path, spliced_seq, **kwargs):
+def run_weak_start(tmp_path, spliced_seq, intron=WEAK_START_INTRON, **kwargs):
     gff = tmp_path / "in.gff"
     fasta = tmp_path / "genome.fa"
     out = tmp_path / "out.gff"
     gff.write_text(build_gff(WEAK_START_BLOCKS, "+"))
-    fasta.write_text(">chr1\n" + build_weak_start_chromosome(spliced_seq) + "\n")
+    fasta.write_text(
+        ">chr1\n" + build_weak_start_chromosome(spliced_seq, intron) + "\n"
+    )
 
     options: dict[str, object] = {
         "max_shift": 300,
@@ -502,8 +621,8 @@ def run_weak_start(tmp_path, spliced_seq, **kwargs):
         "report_path": None,
         "fix_weak_starts": True,
         "weak_start_threshold": 9,
-        "kozak_margin": 1.0,
-        "weak_kozak_threshold": 0.0,
+        "kozak_margin": 0.5,
+        "weak_kozak_threshold": 5.0,
     }
     options.update(kwargs)
     stats = fix_orf.fix_orf(
@@ -518,6 +637,54 @@ def run_weak_start(tmp_path, spliced_seq, **kwargs):
 
 def test_weak_start_with_a_better_candidate_is_repaired(tiny_kozak_pwm, tmp_path):
     stats, records = run_weak_start(tmp_path, WEAK_STRONG_SEQ)
+
+    assert stats["repaired"] == 1
+    assert exonic(records) == sorted(
+        [
+            (101, 110, "five_prime_UTR", "."),
+            (151, 153, "five_prime_UTR", "."),
+            (154, 162, "CDS", "0"),
+            (163, 166, "three_prime_UTR", "."),
+        ]
+    )
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "repaired"
+    assert attributes["orf_issue"] == "weak_start_kozak"
+
+
+def test_weak_start_noncanonical_intron_blocks_switch_by_default(
+    tiny_kozak_pwm, tmp_path
+):
+    """The same sequence/candidate that gets switched in
+    test_weak_start_with_a_better_candidate_is_repaired must NOT be switched
+    when the transcript's intron is non-canonical: an active repair needs
+    trustworthy splice calls, same as the pre-existing invalid-ORF repair
+    path. The transcript is left as its already-valid original ORF."""
+    stats, records = run_weak_start(
+        tmp_path, WEAK_STRONG_SEQ, intron=WEAK_START_NONCANONICAL_INTRON
+    )
+
+    assert stats["repaired"] == 0
+    assert stats["complete"] == 1
+    assert exonic(records) == sorted(WEAK_START_BLOCKS)
+    attributes = mrna_attributes(records)
+    assert attributes["orf_status"] == "complete"
+    assert "orf_issue" not in attributes
+
+
+def test_weak_start_noncanonical_intron_switch_can_be_opted_into(
+    tiny_kozak_pwm, tmp_path
+):
+    """The same non-canonical-intron transcript IS switched when
+    require_canonical=False, mirroring
+    test_noncanonical_introns_can_be_opted_into for the existing repair
+    path."""
+    stats, records = run_weak_start(
+        tmp_path,
+        WEAK_STRONG_SEQ,
+        intron=WEAK_START_NONCANONICAL_INTRON,
+        require_canonical=False,
+    )
 
     assert stats["repaired"] == 1
     assert exonic(records) == sorted(

--- a/src/tests/test_fix_orf.py
+++ b/src/tests/test_fix_orf.py
@@ -102,7 +102,7 @@ def run(tmp_path, blocks, strand, intron=CANONICAL_INTRON, **kwargs):
         "report_path": None,
         "fix_weak_starts": True,
         "weak_start_threshold": 9,
-        "kozak_margin": 0.5,
+        "kozak_margin": 3.0,
         "weak_kozak_threshold": 5.0,
     }
     options.update(kwargs)
@@ -621,7 +621,7 @@ def run_weak_start(tmp_path, spliced_seq, intron=WEAK_START_INTRON, **kwargs):
         "report_path": None,
         "fix_weak_starts": True,
         "weak_start_threshold": 9,
-        "kozak_margin": 0.5,
+        "kozak_margin": 3.0,
         "weak_kozak_threshold": 5.0,
     }
     options.update(kwargs)
@@ -767,7 +767,7 @@ def test_weak_start_search_does_not_trigger_for_a_long_first_exon(
         report_path=None,
         fix_weak_starts=True,
         weak_start_threshold=9,
-        kozak_margin=1.0,
+        kozak_margin=3.0,
         weak_kozak_threshold=0.0,
     )
     assert stats["repaired"] == 0

--- a/src/tests/test_frame_crf.py
+++ b/src/tests/test_frame_crf.py
@@ -156,6 +156,40 @@ def test_every_state_is_connected():
     assert destinations == set(range(len(graph.states)))
 
 
+def test_one_graph_builds_edges_for_two_different_matrices():
+    """A single FrameStateGraph must be safe to reuse for multiple decodes
+    under different transition matrices -- states are config-only and built
+    once, but edges depend on the matrix too and must reflect whichever
+    matrix build_edges was just called with, not stale weights from a
+    previous call."""
+    graph = fh.FrameStateGraph()
+    plant = plant_matrix()
+    animal = token_transition_probs(
+        remove_incomplete_features=True, domain="animal"
+    ).values
+
+    plant_edges = graph.build_edges(plant)
+    animal_edges = graph.build_edges(animal)
+
+    fh.validate_edges(plant_edges, fh.build_mask_table(), graph.states)
+    fh.validate_edges(animal_edges, fh.build_mask_table(), graph.states)
+
+    # Same topology (same graph, same config) but generally different
+    # weights, since the two domains' transition matrices differ.
+    plant_by_edge = {(s, d): w for s, d, w in plant_edges}
+    animal_by_edge = {(s, d): w for s, d, w in animal_edges}
+    assert set(plant_by_edge) == set(animal_by_edge)
+    assert plant_by_edge != animal_by_edge
+
+    sequence, labels = build_locus(VALID_CODING, split=50)
+    codes = fh.encode_sequence(sequence)
+    probs = emissions_from(labels, 0.9)
+    decoded_plant = graph.decode(probs, codes, plant)
+    decoded_animal = graph.decode(probs, codes, animal)
+    assert np.array_equal(decoded_plant, labels)
+    assert np.array_equal(decoded_animal, labels)
+
+
 def test_mask_table_treats_ambiguous_bases_conservatively():
     table = fh.build_mask_table()
     # An N can never be read as a specific base ...

--- a/src/tests/test_frame_crf.py
+++ b/src/tests/test_frame_crf.py
@@ -129,7 +129,8 @@ def test_expanded_graph_is_a_valid_probability_model(domain, remove_incomplete):
     matrix = token_transition_probs(
         remove_incomplete_features=remove_incomplete, domain=domain
     ).values
-    edges = fh.build_edges(matrix)
+    graph = fh.FrameStateGraph()
+    edges = graph.build_edges(matrix)
     fh.validate_edges(edges, fh.build_mask_table())  # raises if violated
 
     mask_table = fh.build_mask_table()
@@ -141,17 +142,18 @@ def test_expanded_graph_is_a_valid_probability_model(domain, remove_incomplete):
             total = sum(
                 weight
                 for destination, weight in successors
-                if mask_table[fh.STATES[destination].mask, base]
+                if mask_table[graph.states[destination].mask, base]
             )
-            assert total <= 1.0 + 1e-9, fh.STATES[source].name
+            assert total <= 1.0 + 1e-9, graph.states[source].name
 
 
 def test_every_state_is_connected():
-    edges = fh.build_edges(plant_matrix())
+    graph = fh.FrameStateGraph()
+    edges = graph.build_edges(plant_matrix())
     sources = {source for source, _, _ in edges}
     destinations = {destination for _, destination, _ in edges}
-    assert sources == set(range(fh.N_STATES))
-    assert destinations == set(range(fh.N_STATES))
+    assert sources == set(range(len(graph.states)))
+    assert destinations == set(range(len(graph.states)))
 
 
 def test_mask_table_treats_ambiguous_bases_conservatively():
@@ -361,7 +363,7 @@ def test_decoded_introns_are_always_canonical(seed):
     introns = decoded_introns(sequence, decoded)
     assert introns, "expected at least one intron"
     for intron in introns:
-        assert len(intron) >= fh.MIN_INTRON_LENGTH
+        assert len(intron) >= fh.DEFAULT_MIN_INTRON_LENGTH
         assert (intron[:2], intron[-2:]) in (("GT", "AG"), ("GC", "AG")), intron[:8]
 
 
@@ -394,8 +396,11 @@ def test_backpointer_memory_does_not_grow_with_minimum_intron_length(min_intron_
     Isolated from the minimum-exon-length lock chain (min_coding_run_length=0) since
     that adds its own states independent of min_intron_length.
     """
-    states = fh.build_states(min_intron_length, min_coding_run_length=0)
-    edges = fh.build_edges(plant_matrix(), min_intron_length, min_coding_run_length=0)
+    graph = fh.FrameStateGraph(
+        min_intron_length=min_intron_length, min_coding_run_length=0
+    )
+    states = graph.states
+    edges = graph.build_edges(plant_matrix())
     fh.validate_edges(edges, fh.build_mask_table(), states)
     index = fh.build_predecessor_csr(edges, len(states))
 
@@ -459,8 +464,9 @@ def test_exon_lock_graph_is_a_valid_probability_model(min_coding_run_length):
     held to: no state may emit more than unit probability at any base, and
     every state must be reachable and have somewhere to go."""
     matrix = plant_matrix()
-    states = fh.build_states(min_coding_run_length=min_coding_run_length)
-    edges = fh.build_edges(matrix, min_coding_run_length=min_coding_run_length)
+    graph = fh.FrameStateGraph(min_coding_run_length=min_coding_run_length)
+    states = graph.states
+    edges = graph.build_edges(matrix)
     fh.validate_edges(edges, fh.build_mask_table(), states)  # raises if violated
 
     sources = {source for source, _, _ in edges}
@@ -548,12 +554,12 @@ def test_exon_length_penalty_graph_is_a_valid_probability_model(
     """The soft escape edges must not break the same invariants the hard
     lock chain was already held to."""
     matrix = plant_matrix()
-    states = fh.build_states(min_coding_run_length=min_coding_run_length)
-    edges = fh.build_edges(
-        matrix,
+    graph = fh.FrameStateGraph(
         min_coding_run_length=min_coding_run_length,
         exon_length_strictness=exon_length_strictness,
     )
+    states = graph.states
+    edges = graph.build_edges(matrix)
     fh.validate_edges(edges, fh.build_mask_table(), states)
 
     sources = {source for source, _, _ in edges}
@@ -566,8 +572,9 @@ def test_min_coding_run_length_zero_reproduces_the_original_graph():
     """min_coding_run_length=0 is the escape hatch: it must add no states or edges
     beyond what the graph looked like before this constraint existed."""
     matrix = plant_matrix()
-    states = fh.build_states(min_coding_run_length=0)
-    edges = fh.build_edges(matrix, min_coding_run_length=0)
+    graph = fh.FrameStateGraph(min_coding_run_length=0)
+    states = graph.states
+    edges = graph.build_edges(matrix)
 
     state_names = {state.name for state in states}
     assert not any(name.startswith("lock") for name in state_names)
@@ -585,15 +592,13 @@ def test_include_utr_in_coding_run_graph_is_a_valid_probability_model(
     across the full range of reachable lock levels (including the ones
     narrowed by start_lock_states to avoid unreachable states)."""
     matrix = plant_matrix()
-    states = fh.build_states(
-        min_coding_run_length=min_coding_run_length, include_utr_in_coding_run=True
-    )
-    edges = fh.build_edges(
-        matrix,
+    graph = fh.FrameStateGraph(
         min_coding_run_length=min_coding_run_length,
         exon_length_strictness=exon_length_strictness,
         include_utr_in_coding_run=True,
     )
+    states = graph.states
+    edges = graph.build_edges(matrix)
     fh.validate_edges(edges, fh.build_mask_table(), states)
 
     sources = {source for source, _, _ in edges}
@@ -686,8 +691,9 @@ def test_splice_motif_groups_do_not_cross_pair():
     """A GT donor may only resume through an AG acceptor, and an AT donor only
     through AC, even when both groups are enabled -- donor and acceptor come
     from the same sub-chain, never mixed across groups."""
-    states = fh.build_states(splice_motif_groups=(fh.GT_AG, fh.AT_AC))
-    edges = fh.build_edges(plant_matrix(), splice_motif_groups=(fh.GT_AG, fh.AT_AC))
+    graph = fh.FrameStateGraph(splice_motif_groups=(fh.GT_AG, fh.AT_AC))
+    states = graph.states
+    edges = graph.build_edges(plant_matrix())
     fh.validate_edges(edges, fh.build_mask_table(), states)
 
     by_name = {state.name: i for i, state in enumerate(states)}
@@ -715,8 +721,9 @@ def test_utr5_intron_resume_uses_measured_transition_ratio():
     assert matrix[U5, U5] == pytest.approx(0.9945, abs=0.01)
     assert matrix[U5, CDS] == pytest.approx(0.0046, abs=0.01)
 
-    states = fh.build_states(include_utr_in_coding_run=False)
-    edges = fh.build_edges(matrix, include_utr_in_coding_run=False)
+    graph = fh.FrameStateGraph(include_utr_in_coding_run=False)
+    states = graph.states
+    edges = graph.build_edges(matrix)
     by_name = {state.name: i for i, state in enumerate(states)}
     acceptor_2 = by_name["intron_utr5_gtag_a2"]
 
@@ -747,15 +754,20 @@ def test_returning_expanded_states_maps_back_to_features():
     states = fh.frame_aware_decode(
         emissions_from(labels, 0.9), codes, plant_matrix(), return_states=True
     )
-    state_feature = np.array([state.feature for state in fh.STATES])
+    state_feature = np.array([state.feature for state in fh.DEFAULT_GRAPH.states])
     assert np.array_equal(state_feature[states], features)
 
     # The start codon really is decoded through the dedicated start states
     coding_start = int(np.argmax(features == CDS))
-    assert [fh.STATES[s].name for s in states[coding_start : coding_start + 3]] == [
+    assert [
+        fh.DEFAULT_GRAPH.states[s].name for s in states[coding_start : coding_start + 3]
+    ] == [
         "start_a",
         "start_t",
         "start_g",
     ]
     coding_end = len(features) - 1 - int(np.argmax((features == CDS)[::-1]))
-    assert fh.STATES[states[coding_end]].name in ("stop_end_a", "stop_end_g")
+    assert fh.DEFAULT_GRAPH.states[states[coding_end]].name in (
+        "stop_end_a",
+        "stop_end_g",
+    )

--- a/src/tests/test_frame_crf.py
+++ b/src/tests/test_frame_crf.py
@@ -422,6 +422,11 @@ def test_minimum_intron_length_is_enforced():
         assert is_valid_orf(coding)
 
 
+def test_min_intron_length_below_structural_minimum_is_rejected():
+    with pytest.raises(ValueError, match="min_intron_length must be at least"):
+        fh.FrameStateGraph(min_intron_length=fh.STRUCTURAL_MIN_INTRON_LENGTH - 1)
+
+
 @pytest.mark.parametrize("min_intron_length", [5, 20, 40])
 def test_backpointer_memory_does_not_grow_with_minimum_intron_length(min_intron_length):
     """The mandatory body states have one predecessor each, so raising the
@@ -624,7 +629,8 @@ def test_include_utr_in_coding_run_graph_is_a_valid_probability_model(
     """The 5' UTR + start-codon lock chain used by include_utr_in_coding_run
     must not break the same invariants the CDS-only lock chain is held to,
     across the full range of reachable lock levels (including the ones
-    narrowed by start_lock_states to avoid unreachable states)."""
+    narrowed by FrameStateGraph._start_lock_states to avoid unreachable
+    states)."""
     matrix = plant_matrix()
     graph = fh.FrameStateGraph(
         min_coding_run_length=min_coding_run_length,


### PR DESCRIPTION
## FrameStateGraph

`frame_crf.py`'s state-graph builders (`build_states`, `build_edges`, and the lock-chain helpers) threaded five config values through many free functions independently, with no guarantee that two call sites building "the same" graph actually agreed on the values. Replaces this with a single `FrameStateGraph` frozen dataclass that owns `min_intron_length`, `splice_motif_groups`, `min_coding_run_length`, `exon_length_strictness`, and `include_utr_in_coding_run` once at construction. `frame_aware_decode`'s public signature and behavior are unchanged, so `detect_intervals.py` needs no changes. Verified bit-identical decoder output against the pre-refactor implementation across 162 config combinations and on real _Oropetium thomaeum_ predictions (12 scaffolds, both strands, plus a parameter sweep on a 687kb gene-dense scaffold).

## fix_orf: Kozak-scored repair of weak start codons

Real predictions were found to over-predict short first coding exons relative to the Phytozome reference for _Oropetium thomaeum_ (2.25x at <9nt). Splitting the excess by whether a real gene overlaps the predicted locus: ~68% is a correctly-located gene where the decoder picked a structurally-valid-but-wrong start codon; ~32% has no real gene there at all. `min_coding_run_length`/`exon_length_strictness` in `frame_crf.py` were already tuned to near their practical ceiling and only partially address the first case; a single-position emission adjustment tested against real data had no measurable effect (diluted across the Viterbi path's cumulative score).

`fix_orf.py` already scans every candidate start codon in a transcript's spliced sequence when repairing an invalid ORF (`find_best_orf`); it just never did this for a CDS that was already valid. Adds `find_best_start_by_kozak`, which reuses that scan but ranks candidates by a Kozak-context PWM (fit from 438k confirmed start codons across 11 Phytozome species, excluding species used for validation) instead of movement distance, restricted to same-frame, same-stop candidates so a switch can never change the encoded protein. Wired into `repair_transcript` so a transcript is only reconsidered when its first coding exon is below `--weak-start-threshold` (default 9nt).

A single fixed `--kozak-margin` doesn't carry the same reliability into every species. Cross-species validation against confident, unambiguous start calls found one genome net-negative at the fixed default. `calibrate_kozak_margin` fixes this per-genome: every genome already has thousands of transcripts whose start isn't ambiguous, and running the same switch logic against those known-correct starts measures directly how often the rule would talk itself into a wrong switch, raising the margin only as far as needed to keep that rate at or below 2%. Cross-species precision on TIS-changing switches moves from 66.3% to 78.3% with calibration on, and the previously net-negative species stops triggering wrong switches entirely. On by default, opt out with `--no-calibrate-kozak-margin`.

## Smaller fixes found along the way

- `predict_and_visualize.py` never passed `--input-fasta` through to `detect_intervals`, so it silently decoded with the non-frame-aware 5-state Viterbi instead of matching `predict.sh`'s default behavior.
- The `intergenic_bias_sweep` scripts had drifted out of sync with a CLI refactor (subcommands that no longer exist, removed flags); updated to call the current standalone scripts and pass `--input-fasta` through.
